### PR TITLE
Added support for OpenCode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,76 +1,76 @@
 {
-    "name": "rse-agents",
-    "owner": {
-        "name": "UW SSEC Team",
+  "name": "rse-agents",
+  "owner": {
+    "name": "UW SSEC Team",
+    "url": "https://github.com/uw-ssec"
+  },
+  "metadata": {
+    "description": "Custom AI agents for Research Software Engineering (RSE) and Scientific Computing tasks",
+    "version": "0.1.1"
+  },
+  "plugins": [
+    {
+      "name": "python-development",
+      "source": "./plugins",
+      "description": "Agents and skills for Scientific Python development and best practices",
+      "version": "0.1.1",
+      "author": {
+        "name": "Landung Setiawan",
+        "url": "https://github.com/lsetiawan"
+      },
+      "homepage": "https://github.com/uw-ssec/rse-agents",
+      "repository": "https://github.com/uw-ssec/rse-agents",
+      "license": "MIT",
+      "keywords": [
+        "python",
+        "scientific-computing",
+        "research-software-engineering",
+        "rse",
+        "ai-agents",
+        "claude-plugins"
+      ],
+      "category": "development",
+      "strict": false,
+      "agents": [
+        "./plugins/agents/scientific-python-expert.md"
+      ],
+      "skills": [
+        "./plugins/skills/pixi-package-manager",
+        "./plugins/skills/python-packaging",
+        "./plugins/skills/python-testing",
+        "./plugins/skills/code-quality-tools"
+      ]
+    },
+    {
+      "name": "scientific-domain-applications",
+      "source": "./plugins",
+      "description": "Domain-specific scientific computing agents and skills for astronomy, geospatial analysis, climate science, and interactive visualization",
+      "version": "0.2.0",
+      "author": {
+        "name": "SSEC Research Team",
         "url": "https://github.com/uw-ssec"
-    },
-    "metadata": {
-        "description": "Custom AI agents for Research Software Engineering (RSE) and Scientific Computing tasks",
-        "version": "0.1.1"
-    },
-    "plugins": [
-        {
-            "name": "python-development",
-            "source": "./plugins",
-            "description": "Agents and skills for Scientific Python development and best practices",
-            "version": "0.1.1",
-            "author": {
-                "name": "Landung Setiawan",
-                "url": "https://github.com/lsetiawan"
-            },
-            "homepage": "https://github.com/uw-ssec/rse-agents",
-            "repository": "https://github.com/uw-ssec/rse-agents",
-            "license": "MIT",
-            "keywords": [
-                "python",
-                "scientific-computing",
-                "research-software-engineering",
-                "rse",
-                "ai-agents",
-                "claude-plugins"
-            ],
-            "category": "development",
-            "strict": false,
-            "agents": [
-                "./agents/scientific-python-expert.md"
-            ],
-            "skills": [
-                "./skills/pixi-package-manager",
-                "./skills/python-packaging",
-                "./skills/python-testing",
-                "./skills/code-quality-tools"
-            ]
-        },
-        {
-            "name": "scientific-domain-applications",
-            "source": "./plugins",
-            "description": "Domain-specific scientific computing agents and skills for astronomy, geospatial analysis, climate science, and interactive visualization",
-            "version": "0.2.0",
-            "author": {
-                "name": "SSEC Research Team",
-                "url": "https://github.com/uw-ssec"
-            },
-            "homepage": "https://github.com/uw-ssec/rse-agents",
-            "repository": "https://github.com/uw-ssec/rse-agents",
-            "license": "MIT",
-            "keywords": [
-                "astronomy",
-                "astrophysics",
-                "astropy",
-                "xarray",
-                "geospatial",
-                "climate",
-                "visualization",
-                "scientific-computing"
-            ],
-            "category": "data-science",
-            "strict": false,
-            "agents": [
-                "./agents/astronomy-astrophysics-expert.md"
-            ],
-            "skills": [
-                "./skills/xarray-for-multidimensional-data"
-            ]
-        }
-    ]
+      },
+      "homepage": "https://github.com/uw-ssec/rse-agents",
+      "repository": "https://github.com/uw-ssec/rse-agents",
+      "license": "MIT",
+      "keywords": [
+        "astronomy",
+        "astrophysics",
+        "astropy",
+        "xarray",
+        "geospatial",
+        "climate",
+        "visualization",
+        "scientific-computing"
+      ],
+      "category": "data-science",
+      "strict": false,
+      "agents": [
+        "./plugins/agents/astronomy-astrophysics-expert.md"
+      ],
+      "skills": [
+        "./plugins/skills/xarray-for-multidimensional-data"
+      ]
+    }
+  ]
 }

--- a/.opencode/skill/code-quality-tools
+++ b/.opencode/skill/code-quality-tools
@@ -1,0 +1,1 @@
+../../plugins/skills/code-quality-tools

--- a/.opencode/skill/pixi-package-manager
+++ b/.opencode/skill/pixi-package-manager
@@ -1,0 +1,1 @@
+../../plugins/skills/pixi-package-manager

--- a/.opencode/skill/python-packaging
+++ b/.opencode/skill/python-packaging
@@ -1,0 +1,1 @@
+../../plugins/skills/python-packaging

--- a/.opencode/skill/python-testing
+++ b/.opencode/skill/python-testing
@@ -1,0 +1,1 @@
+../../plugins/skills/python-testing

--- a/.opencode/skill/xarray-for-multidimensional-data
+++ b/.opencode/skill/xarray-for-multidimensional-data
@@ -1,0 +1,1 @@
+../../plugins/skills/xarray-for-multidimensional-data

--- a/README.md
+++ b/README.md
@@ -1,155 +1,221 @@
 # RSE Agents
 
-Custom AI agents and skills for Research Software Engineering (RSE) and Scientific Computing tasks, designed for use with [Claude Code](https://www.anthropic.com/claude/code) and compatible AI coding assistants.
+Custom AI agents and skills for Research Software Engineering (RSE) and Scientific Computing tasks, designed for use with **Claude Code** and **OpenCode** — two powerful AI coding assistants that support local and cloud-based plugin and skill integrations.
+
+---
 
 ## Purpose
 
-This repository provides specialized agents and skills that understand the unique challenges of scientific software development, including:
+This repository provides a unified collection of **agents** and **skills** that specialize in the scientific software development ecosystem. These components are designed to assist with:
 
-- Modern Scientific Python development following community best practices
-- Reproducible environment management with pixi
-- Python packaging and distribution with pyproject.toml
-- Comprehensive testing strategies with pytest
-- Scientific computing workflows and numerical methods
-- Research software engineering practices
-- High-performance computing (HPC) patterns
-- Scientific Python ecosystem (NumPy, Pandas, SciPy, Matplotlib, Xarray, etc.)
+- Modern Scientific Python development using community best practices
+- Reproducible environment management with **pixi**
+- Packaging and distribution with **pyproject.toml**
+- Comprehensive testing strategies using **pytest**
+- Numerical and scientific computing workflows
+- Research software engineering principles and maintainability
+- High-performance computing (HPC) and performance optimization
+- Integration with the **Scientific Python** ecosystem (NumPy, Pandas, SciPy, Matplotlib, Xarray, etc.)
+
+The repository is structured to support **cross-compatibility** between Claude Code and OpenCode, providing a single source of truth for both ecosystems.
+
+---
 
 ## Installation
 
-To use these agents and skills in Claude Code, add this repository to your plugin marketplace:
+### **For Claude Code**
+
+To install and use these agents and skills in Claude Code, add this repository to your Claude plugin marketplace:
 
 ```bash
 /plugin marketplace add uw-ssec/rse-agents
 ```
 
-Once installed, the agents and skills will be available in your Claude Code environment and can be invoked when working on scientific software projects.
+Once installed, the agents and skills will appear in the Claude Code plugin list and can be invoked directly within the editor environment.
+
+### **For OpenCode**
+
+To use the same skills and agents in OpenCode, simply ensure this repository is cloned locally with a valid `opencode.json` in place. OpenCode will automatically detect and load agents and skills without requiring any manual attach or linking steps:
+
+```bash
+If you add new skills or modify existing ones, sync the links using the provided script (see below).
+```
+
+---
 
 ## Available Plugins
 
-The repository provides Claude Code plugins organized by domain. Each plugin contains agents (specialized AI personas) and skills (reusable knowledge modules).
+This repository provides two primary plugin domains:
 
-### Python Development Plugin
+### 🧩 **Python Development Plugin**
 
-Expert agents and comprehensive skills for modern Scientific Python development.
+Expert agents and reusable skills for scientific and modern Python development.
 
-**Location:** [plugins/python-development/](plugins/python-development/)
+**Location:** `plugins/python-development/`
 
 **Agents:**
-- **Scientific Python Expert** - Comprehensive agent for scientific Python development following [Scientific Python Development Guide](https://learn.scientific-python.org/development/) best practices
+
+- **Scientific Python Expert** — comprehensive agent following [Scientific Python Development Guide](https://learn.scientific-python.org/development/) standards.
 
 **Skills:**
-- **pixi-package-manager** - Fast, reproducible scientific Python environments with unified conda and PyPI management
-- **python-packaging** - Modern packaging with pyproject.toml, src layout, and Hatchling build backend
-- **python-testing** - Robust testing strategies with pytest following Scientific Python community guidelines
 
-**When to use:** Scientific computing projects, data analysis pipelines, research software development, package creation, reproducible research workflows
+- `pixi-package-manager` — reproducible scientific Python environments
+- `python-packaging` — modern packaging and project structure
+- `python-testing` — robust testing with `pytest`
+- `code-quality-tools` — integrated tools for linting and type checking (ruff, mypy, pre-commit)
 
-### Scientific Computing Plugin
+### 🧠 **Scientific Computing Plugin**
 
-Agents for computational science, numerical methods, and high-performance computing.
+Agents and skills for computational science, numerical methods, and high-performance computing.
 
-**Location:** [plugins/scientific-computing/](plugins/scientific-computing/)
+**Location:** `plugins/scientific-computing/`
 
-**Status:** Plugin structure in place, agents coming soon
+**Agents:**
 
-**Planned focus areas:** HPC workflows, parallel computing, numerical algorithms, scientific simulations, performance optimization
+- **Astronomy & Astrophysics Expert** — provides domain expertise in astronomy, astrophysics, and scientific computing workflows, integrating astropy and xarray-based analysis.
 
-Browse the [plugins directory](plugins/) to explore all available plugins.
+**Skills:**
+
+- `xarray-for-multidimensional-data` — skill for managing and analyzing multi-dimensional scientific data using Xarray and related tools.
+
+**Planned Focus Areas:** HPC workflows, simulations, performance optimization, numerical methods, and domain-specific scientific data handling.
+
+---
 
 ## Repository Structure
 
 ```
 rse-agents/
 ├── .claude-plugin/
-│   └── marketplace.json        # Claude plugin marketplace configuration
+│   └── marketplace.json         # Claude Code marketplace manifest
+├── .opencode/
+│   └── skills/                  # Symlinked skill definitions for OpenCode
 ├── plugins/
-│   ├── python-development/     # Scientific Python development plugin
-│   │   ├── agents/
-│   │   │   └── scientific-python-expert.md
-│   │   ├── skills/
-│   │   │   ├── pixi-package-manager/
-│   │   │   │   └── SKILL.md
-│   │   │   ├── python-packaging/
-│   │   │   │   └── SKILL.md
-│   │   │   └── python-testing/
-│   │   │       └── SKILL.md
-│   │   └── README.md
-│   ├── scientific-computing/   # Scientific computing plugin (planned)
-│   │   ├── agents/
-│   │   └── README.md
-│   └── README.md               # Plugin directory overview
-├── CONTRIBUTING.md             # Contribution guidelines
-├── LICENSE                     # BSD 3-Clause License
-└── README.md                   # This file
+│   ├── agents/                  # Shared agent definitions
+│   └── skills/                  # Shared skill definitions (single source of truth)
+├── scripts/
+│   └── sync_opencode_skills.sh  # Script to refresh OpenCode skill symlinks
+├── shared/
+│   └── plugin-manifest.shared.json  # Shared metadata for both Claude and OpenCode
+├── LICENSE
+├── CONTRIBUTING.md
+├── opencode.json                # Configuration for Opencode
+├── pixi.toml
+└── README.md                    # This file
 ```
 
-## Architecture
+---
 
-### Plugin System
+## Sync Script
 
-This repository uses the Claude Code plugin marketplace architecture:
+The repository includes a helper script to keep **Claude Code** and **OpenCode** in sync whenever new skills are added.
 
-- **Plugins** - Top-level containers organized by domain (e.g., python-development, scientific-computing)
-- **Agents** - Specialized AI personas with comprehensive expertise in specific areas
-- **Skills** - Reusable knowledge modules that provide detailed guidance on specific topics
+Run this script from the repository root:
 
-### Design Philosophy
+```bash
+./scripts/sync_opencode_skills.sh
+```
 
-The agents and skills follow the [Scientific Python Development Guide](https://learn.scientific-python.org/development/) principles:
+This automatically updates `.opencode/skills/` to match `plugins/skills/` by creating or refreshing symbolic links.
 
-1. **Collaborate** - Adopt conventions and tooling used by the broader scientific Python community
-2. **Refactor Fearlessly** - Leverage tests and tools to enable confident iteration
-3. **Prefer Wide Over Deep** - Build reusable, extensible solutions for unforeseen applications
+### When to Run:
 
-### Agent vs Skill
+- After adding a new skill under `plugins/skills/`
+- After restructuring or renaming a skill directory
 
-- **Agents** - Comprehensive personas that handle complete workflows, make decisions, and provide end-to-end guidance
-- **Skills** - Focused knowledge modules on specific topics (e.g., testing patterns, packaging workflows) that agents can reference
+---
+
+## Adding a New Skill
+
+### Step 1 — Create the Skill Folder
+
+Add a new folder inside `plugins/skills/`:
+
+```
+plugins/skills/my-new-skill/
+```
+
+Inside it, create a file named `SKILL.md` containing your skill definition and description.
+
+### Step 2 — Sync Skills for OpenCode
+
+Run the following command:
+
+```bash
+./scripts/sync_opencode_skills.sh
+```
+
+This ensures OpenCode can discover the new skill under `.opencode/skills/`.
+
+
+---
+
+## Activation
+
+### **Activate in Claude Code**
+
+Once installed, agents can be invoked directly:
+
+```bash
+@scientific-python-expert please explain your capabilities
+```
+
+Claude Code automatically loads all related skills declared in the plugin manifest.
+
+### **Activate in OpenCode**
+
+Once linked, agents are automatically available when OpenCode is launched in the repository. Use `/agents` command or simply tab over to one of the custom agents
+
+---
+
+## Design Philosophy
+
+These agents and skills follow th[e ](https://learn.scientific-python.org/development/)[Scientific Python Development Guide](https://learn.scientific-python.org/development/) and the RSE community principles:
+
+1. **Collaborate** — Use community-standard tooling and conventions.
+2. **Refactor Fearlessly** — Maintain high test coverage for confident iteration.
+3. **Prefer Wide Over Deep** — Build reusable, extensible components.
+
+---
 
 ## Contributing
 
-We welcome contributions of new agents, skills, and improvements! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
+Contributions are welcome! Please review [CONTRIBUTING.md](CONTRIBUTING.md) for:
 
 - Creating new agents and skills
-- Plugin organization and structure
-- Naming conventions and best practices
-- Testing and validation
+- Repository structure guidelines
+- Testing and best practices
 - Submitting pull requests
 
-## Documentation
-
-For detailed information about the plugins and their contents:
-
-- [Plugins Overview](plugins/README.md) - Complete overview of all plugins
-- [Python Development Plugin](plugins/python-development/README.md) - Scientific Python agents and skills
-- [Scientific Computing Plugin](plugins/scientific-computing/README.md) - HPC and computational science
-- [Contributing Guidelines](CONTRIBUTING.md) - How to contribute
+---
 
 ## Related Resources
 
-### Scientific Python Community
-- [Scientific Python Development Guide](https://learn.scientific-python.org/development/) - Community best practices
-- [Scientific Python Lectures](https://lectures.scientific-python.org/) - Educational materials
-- [NumPy](https://numpy.org/), [SciPy](https://scipy.org/), [Pandas](https://pandas.pydata.org/) - Core libraries
+### Scientific Python
+
+- [Scientific Python Development Guide](https://learn.scientific-python.org/development/)
+- [NumPy](https://numpy.org/)[, ](https://scipy.org/)[SciPy](https://scipy.org/)[, ](https://matplotlib.org/)[Matplotlib](https://matplotlib.org/)
 
 ### Research Software Engineering
-- [UW Scientific Software Engineering Center](https://escience.washington.edu/software-engineering/)
-- [Best Practices for Scientific Computing](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1001745)
-- [The Turing Way](https://the-turing-way.netlify.app/) - Guide to reproducible research
 
-### Claude Code
-- [Claude Code Documentation](https://docs.anthropic.com/claude/docs)
-- [Claude Plugin Marketplace](https://code.claude.com/docs/en/plugins)
+- [UW-SSEC](https://escience.washington.edu/software-engineering/)
+- [Best Practices for Scientific Computing](https://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1001745)
+
+### Tools
+
+- [Claude Code](https://www.anthropic.com/claude/code)
+- [OpenCode](https://opencode.ai)
+
+---
 
 ## License
 
-This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the **BSD 3-Clause License**. See the [LICENSE](LICENSE) file for details.
+
+---
 
 ## Acknowledgments
 
-Developed and maintained by the University of Washington Scientific Software Engineering Center (UW-SSEC).
+Developed and maintained by the **University of Washington Scientific Software Engineering Center (UW-SSEC)**.
 
-## Questions or Issues?
-
-Please open an issue on [GitHub](https://github.com/uw-ssec/rse-agents/issues).
+For support or issues, please open a ticket o[n ](https://github.com/uw-ssec/rse-agents/issues)[GitHub Issues](https://github.com/uw-ssec/rse-agents/issues).

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "scientific-python-expert": {
+      "description": "Helps build reproducible, high-quality scientific software for researchers, data scientists, and scientific software engineers.",
+      "model": "anthropic/claude-sonnet-4-5",
+      "prompt": "You are the scientific Python expert from rse-agents. You follow the same conventions as in Claude Code. Use libraries like NumPy, SciPy, Matplotlib, scikit-learn, and best practices from Scientific Python."
+    },
+    "astronomy-astrophysics-expert": {
+      "description": "Provides expertise in astronomy, astrophysics, and scientific computing workflows.",
+      "model": "anthropic/claude-sonnet-4-5",
+      "prompt": "You are the astronomy and astrophysics expert from rse-agents. You specialize in astropy, xarray, and reproducible scientific workflows."
+    }
+  }
+}

--- a/scripts/sync_opencode_skills.sh
+++ b/scripts/sync_opencode_skills.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Sync .opencode/skill symlinks to match plugins/skills
+
+set -e
+mkdir -p .opencode/skill
+
+for skill in plugins/skills/*; do
+  name=$(basename "$skill")
+  link=".opencode/skill/$name"
+  if [ -L "$link" ] || [ -d "$link" ]; then
+    rm -rf "$link"
+  fi
+  ln -s "../../$skill" "$link"
+  echo "Linked skill: $name"
+done
+
+echo "✅ OpenCode skill links refreshed!"

--- a/shared/plugin-manifest.shared.json
+++ b/shared/plugin-manifest.shared.json
@@ -1,0 +1,10 @@
+{
+  "name": "rse-agents",
+  "version": "0.2.0",
+  "description": "...",
+  "maintainer": "...",
+  "paths": {
+    "agents": "./plugins/agents",
+    "skills": "./plugins/skills"
+  }
+}


### PR DESCRIPTION
### Description

This PR (resolves #4 & #30) introduces full **OpenCode compatibility** while maintaining existing **Claude Code support**. The repository is now structured to provide a single source of truth for agents and skills across both platforms.

---

### Key Changes

* Added `opencode.json` configuration for OpenCode agents.
* Created `.opencode/skill/` symlink structure for OpenCode skill discovery.
* Added `scripts/sync_opencode_skills.sh` for automatic skill syncing.
* Updated `README.md` to reflect dual support for Claude Code and OpenCode.
* Consolidated documentation on repository structure, sync instructions, and activation methods.
* Included scientific-domain agents and xarray-related skills in marketplace definitions.

---

### Impact

* Both Claude Code and OpenCode can now load the same agents and skills seamlessly.
* No duplication — all plugin logic references a unified `plugins/` directory.
* Future extensions (e.g., Cursor, Replit, etc.) can integrate using the shared structure.

---

### Testing / Output Screenshots
<img width="784" height="175" alt="Screenshot 2026-01-07 at 5 18 27 AM" src="https://github.com/user-attachments/assets/2a64ec38-9551-4d89-9c8e-40494786fc32" />

<img width="1552" height="1012" alt="Screenshot 2026-01-07 at 5 20 06 AM" src="https://github.com/user-attachments/assets/0af78ea9-ec72-44f6-a006-e8245d22bc60" />

<img width="1552" height="1012" alt="Screenshot 2026-01-07 at 5 20 40 AM" src="https://github.com/user-attachments/assets/166afa6c-3737-456f-b5f2-b5f5fabdf8d5" />

<img width="1552" height="1012" alt="Screenshot 2026-01-07 at 5 21 39 AM" src="https://github.com/user-attachments/assets/6b43c258-150e-424d-a820-4260692db05c" />


