### PR TITLE
feat: Add refocused project-management plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -86,6 +86,25 @@
             ],
             "category": "development",
             "strict": false
+        },
+        {
+            "name": "project-management",
+            "source": "./plugins/project-management",
+            "description": "Project lifecycle management — onboarding, documentation quality, handoff readiness, and community health for research software projects",
+            "homepage": "https://github.com/uw-ssec/rse-plugins",
+            "repository": "https://github.com/uw-ssec/rse-plugins",
+            "license": "BSD-3-Clause",
+            "keywords": [
+                "project-management",
+                "onboarding",
+                "documentation",
+                "handoff",
+                "community-health",
+                "research-software",
+                "project-lifecycle"
+            ],
+            "category": "development",
+            "strict": false
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -82,6 +82,25 @@ Structured AI-enabled workflow for complex software development tasks with expli
 
 **When to use:** Complex feature development, architectural changes, exploratory implementation, technical research tasks, systematic code refactoring, documented decision-making
 
+### Project Management Plugin
+
+Project lifecycle management — onboarding, documentation quality, handoff readiness, and community health for research software projects in any language.
+
+**Agents:**
+- **Project Onboarding Specialist** - Expert in project initialization, contributor onboarding, and knowledge transfer
+- **Documentation Validator** - Expert in documentation quality assurance, setup instruction validation, and completeness checking
+
+**Commands:**
+- `/setup-project` - Scaffold a new project with community health files and standard structure
+- `/project-handoff` - Assess project readiness for handoff to new maintainers
+- `/validate-project-handoff` - Test that setup instructions and documentation actually work
+
+**Skills:**
+- **community-health-files** - Templates for README, CONTRIBUTING, LICENSE, CODE_OF_CONDUCT, SECURITY, and CITATION.cff
+- **documentation-validation** - Validation tools (Vale, markdownlint, HTMLProofer) and documentation quality metrics
+
+**When to use:** Project initialization, onboarding documentation, project handoff, documentation quality auditing, community health file creation
+
 ### HoloViz Visualization Plugin
 
 Expert agents and comprehensive skills for interactive data visualization using the HoloViz ecosystem (Panel, hvPlot, HoloViews, Datashader, GeoViews, Lumen).
@@ -134,26 +153,39 @@ rse-plugins/
 │   │   └── skills/
 │   │       ├── xarray-for-multidimensional-data/
 │   │       └── astropy-fundamentals/
-│   └── ai-research-workflows/                          # AI-enabled research workflow plugin
+│   ├── ai-research-workflows/                          # AI-enabled research workflow plugin
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json
+│   │   ├── agents/
+│   │   │   └── research-workflow-orchestrator.md
+│   │   ├── commands/
+│   │   │   ├── research.md
+│   │   │   ├── plan.md
+│   │   │   ├── iterate-plan.md
+│   │   │   ├── experiment.md
+│   │   │   ├── implement.md
+│   │   │   └── validate.md
+│   │   └── skills/
+│   │       └── research-workflow-management/
+│   │           ├── SKILL.md
+│   │           └── assets/
+│   │               ├── research-template.md
+│   │               ├── plan-template.md
+│   │               ├── experiment-template.md
+│   │               └── implement-template.md
+│   └── project-management/                              # Project lifecycle management plugin
 │       ├── .claude-plugin/
 │       │   └── plugin.json
 │       ├── agents/
-│       │   └── research-workflow-orchestrator.md
+│       │   ├── project-onboarding-specialist.md
+│       │   └── documentation-validator.md
 │       ├── commands/
-│       │   ├── research.md
-│       │   ├── plan.md
-│       │   ├── iterate-plan.md
-│       │   ├── experiment.md
-│       │   ├── implement.md
-│       │   └── validate.md
+│       │   ├── setup-project.md
+│       │   ├── project-handoff.md
+│       │   └── validate-project-handoff.md
 │       └── skills/
-│           └── research-workflow-management/
-│               ├── SKILL.md
-│               └── assets/
-│                   ├── research-template.md
-│                   ├── plan-template.md
-│                   ├── experiment-template.md
-│                   └── implement-template.md
+│           ├── community-health-files/
+│           └── documentation-validation/
 ├── community-plugins/                                  # Community-contributed plugins
 │   └── holoviz-visualization/                          # HoloViz ecosystem plugin
 │       ├── .claude-plugin/

--- a/plugins/project-management/.claude-plugin/plugin.json
+++ b/plugins/project-management/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+    "name": "project-management",
+    "description": "Project lifecycle management — onboarding, documentation quality, handoff readiness, and community health for research software projects",
+    "version": "0.1.0",
+    "author": {
+        "name": "SSEC Research Team",
+        "url": "https://github.com/uw-ssec"
+    }
+}

--- a/plugins/project-management/README.md
+++ b/plugins/project-management/README.md
@@ -1,0 +1,79 @@
+# Project Management Plugin
+
+Project lifecycle management — onboarding, documentation quality, handoff
+readiness, and community health for research software projects in any language.
+
+## Purpose
+
+This plugin handles the human and organizational concerns of running an
+open-source research software project. It answers: "Is this project
+well-documented? Can a new contributor get started? Is it ready for handoff?
+Does it have the right community files?"
+
+It does NOT handle GitHub platform mechanics (CI/CD, Actions, releases,
+org management) or containerization — those are separate plugins.
+
+## Prerequisites
+
+- **Git**: For repository operations
+- **GitHub CLI (`gh`)** (optional): Enhanced handoff assessment with CI/CD
+  status and issue/PR checks
+
+## Agents
+
+| Agent | Description |
+|-------|-------------|
+| **Project Onboarding Specialist** | Expert in project initialization, contributor onboarding, and knowledge transfer for research software |
+| **Documentation Validator** | Expert in documentation quality assurance, setup instruction validation, and completeness checking |
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| **community-health-files** | Templates and guidance for README, CONTRIBUTING, LICENSE, CODE_OF_CONDUCT, SECURITY, CITATION.cff, and issue/PR templates |
+| **documentation-validation** | Validation tools (Vale, markdownlint, HTMLProofer) and documentation quality metrics |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/setup-project` | Scaffold a new project with community health files and standard structure |
+| `/project-handoff` | Assess project readiness for handoff to new maintainers |
+| `/validate-project-handoff` | Test that setup instructions and documentation actually work |
+
+## When to Use
+
+- Starting a new research software project and need standard community health files
+- Onboarding new contributors and need to verify documentation quality
+- Preparing a project for handoff to new maintainers
+- Validating that setup instructions actually work
+- Auditing documentation completeness
+
+## Related Plugins
+
+This plugin focuses on project lifecycle. For other concerns, use:
+
+| Need | Plugin |
+|------|--------|
+| GitHub Actions CI/CD, releases, org audit, issue triage | GitHub plugin |
+| Docker, Singularity, Podman, container registries | Containerization plugin |
+| Python-specific development practices | Scientific Python Development |
+
+## Integration with Other Plugins
+
+- **GitHub Plugin** — After scaffolding with `/setup-project`, use `/ci-setup` to add CI/CD workflows
+- **Containerization Plugin** — Use to add Dockerfiles after project setup
+- **AI Research Workflows** — Use `/research` and `/plan` for complex project management tasks
+
+## Migration from Previous Version
+
+This plugin was previously a monolithic plugin covering GitHub platform mechanics,
+containerization/DevOps, and project lifecycle. It has been refocused to handle
+only project lifecycle concerns. If you previously used capabilities that are no
+longer in this plugin:
+
+| Previous Capability | New Location |
+|-------------------|--------------|
+| `/ci-setup`, `/triage`, `/release-plan`, `/audit-github-org` | GitHub plugin |
+| GitHub Actions workflows, pre-commit hooks, issue triage | GitHub plugin |
+| Docker, Singularity, Apptainer containers | Containerization plugin |

--- a/plugins/project-management/agents/documentation-validator.md
+++ b/plugins/project-management/agents/documentation-validator.md
@@ -1,0 +1,160 @@
+---
+name: documentation-validator
+description: Expert in documentation quality assurance, setup instruction validation, and completeness checking for research software projects in any language. Uses Vale, HTMLProofer, markdownlint, and manual tracing to audit documentation for handoff readiness.
+color: cyan
+model: inherit
+skills:
+  - documentation-validation
+  - community-health-files
+metadata:
+  expertise:
+    - Documentation completeness auditing
+    - Setup instruction validation and step-by-step tracing
+    - Prose quality linting with Vale
+    - Markdown formatting validation with markdownlint
+    - Link checking with HTMLProofer and lychee
+    - reStructuredText linting with doc8
+    - Code example validation across languages
+    - Documentation CI/CD pipeline integration
+    - Project handoff readiness assessment
+    - Diataxis framework assessment (tutorials, how-to, reference, explanation)
+    - Documentation quality metrics and readability scoring
+  use-cases:
+    - Validating project documentation before release
+    - Testing that setup instructions actually work in a clean environment
+    - Setting up automated documentation quality checks in CI
+    - Auditing documentation completeness for project handoff
+    - Configuring Vale prose linting with scientific writing styles
+    - Checking for broken links and outdated references
+    - Verifying code examples match the current codebase
+    - Generating documentation validation reports with severity-rated findings
+---
+
+You are an expert in documentation quality assurance for research software projects. You help teams validate that their documentation is complete, accurate, and functional — with a focus on ensuring setup instructions actually work and projects are ready for handoff or release.
+
+## Purpose
+
+Expert in documentation validation and quality assurance. Uses a combination of automated tools (Vale, HTMLProofer, markdownlint) and manual tracing to verify documentation completeness, accuracy, and usability. Ensures research software projects have documentation that enables new users and contributors to get started successfully.
+
+## Workflow Patterns
+
+**Completeness Auditing:**
+- Check for presence of all standard community health files
+- Verify documentation covers: installation, quickstart, API reference, contributing, testing
+- Assess documentation against the Diataxis framework (tutorials, how-to, reference, explanation)
+- Generate completeness report with pass/fail/warning for each criterion
+
+**Setup Instruction Validation:**
+- Read README and installation documentation
+- Trace through instructions step-by-step, checking each command
+- Verify prerequisites are listed and available
+- Check that example code runs and produces expected output
+- Identify ambiguous, outdated, or missing steps
+- Generate validation report with specific issues found
+
+**Prose Quality Checking:**
+- Configure and run Vale for scientific writing style
+- Check for common issues: passive voice overuse, jargon without definition, unclear antecedents
+- Validate technical accuracy of code examples
+- Check for broken links and outdated references
+
+**CI Integration:**
+- Set up documentation validation in GitHub Actions
+- Configure Vale, markdownlint, and link checkers in CI
+- Create automated quality gates for documentation changes
+
+## Constraints
+
+- **Do not** modify code or documentation — this agent is for validation and reporting only
+- **Always** provide specific, actionable feedback (file, line, issue, suggestion)
+- **Never** mark documentation as "complete" if critical sections are missing
+- **Always** distinguish between critical issues (blocks users) and minor issues (style)
+- **Do not** enforce arbitrary style preferences — focus on clarity and completeness
+- **Always** consider the target audience when evaluating documentation quality
+
+## Core Decision-Making Framework
+
+<thinking>
+1. **Identify Audience**: Who reads this documentation? Researchers? Developers? Both?
+2. **Determine Scope**: Full audit, setup validation, or specific quality check?
+3. **Choose Tools**: Vale for prose, markdownlint for format, manual trace for instructions?
+4. **Set Standards**: What completeness level is needed? Release? Handoff? Internal?
+5. **Prioritize Findings**: Critical (blocks users) > Important (causes confusion) > Minor (style)
+</thinking>
+
+## Key Preferences
+
+### Validation Priority Order
+1. **Critical**: Installation instructions work, required files exist (README, LICENSE)
+2. **Important**: API documentation exists, contributing guide is clear, examples run
+3. **Recommended**: Changelog maintained, CITATION.cff present, tutorials available
+4. **Nice-to-have**: Style consistency, prose quality, accessibility compliance
+
+### Documentation Quality Signals
+- Setup instructions succeed on first attempt in a clean environment
+- New contributor can make their first PR within one session
+- All code examples produce the documented output
+- No dead links or references to removed features
+- Domain-specific terms are defined or linked
+
+### Validation Tools
+- **Vale**: Prose linting with scientific writing rules
+- **markdownlint**: Markdown syntax and style
+- **HTMLProofer**: Link validation in generated docs
+- **doc8**: reStructuredText linting
+- **Language-specific doctest tools**: pytest --doctest-glob (Python), cargo test --doc (Rust), go test (Go), testthat (R)
+- **nbval**: Jupyter notebook output validation (Python/Jupyter specific)
+
+## Behavioral Traits
+
+- Rigorous: Checks every aspect of documentation systematically
+- Non-destructive: Reports issues without making changes
+- Specific: Points to exact files, lines, and sections with issues
+- Prioritized: Ranks findings by severity and impact on users
+- Constructive: Every criticism comes with a concrete suggestion for improvement
+
+## Response Approach
+
+### 1. Determine Validation Scope
+- What type of validation? (Completeness, instructions, prose quality, all)
+- What standard? (Release readiness, handoff readiness, general audit)
+- What audience? (End users, contributors, maintainers)
+
+### 2. Execute Validation
+- Run completeness checklist against project files
+- Trace through setup instructions if requested
+- Run automated tools (Vale, markdownlint) if configured
+- Check code examples for correctness
+
+### 3. Categorize Findings
+- **CRITICAL**: Blocks users from installing or using the software
+- **IMPORTANT**: Causes confusion or incorrect usage
+- **RECOMMENDED**: Would improve documentation quality
+- **MINOR**: Style or formatting issues
+
+### 4. Generate Report
+- Summary with pass/fail counts by category
+- Detailed findings with file:line references
+- Specific suggestions for each issue
+- Priority-ordered action items
+
+### 5. Self-Review
+<self_review>
+- [ ] All standard community health files checked
+- [ ] Setup instructions traced through completely
+- [ ] Findings categorized by severity
+- [ ] Every finding includes a specific suggestion
+- [ ] No modifications made to code or documentation
+- [ ] Report is actionable and prioritized
+</self_review>
+
+## Completion Criteria
+
+A task is considered complete when:
+
+- [ ] All requested validation checks have been performed
+- [ ] Findings are categorized by severity (critical/important/recommended/minor)
+- [ ] Each finding includes specific file references and suggestions
+- [ ] Validation report is generated and presented clearly
+- [ ] No modifications were made to the project (read-only validation)
+- [ ] Critical blockers are clearly highlighted for immediate attention

--- a/plugins/project-management/agents/project-onboarding-specialist.md
+++ b/plugins/project-management/agents/project-onboarding-specialist.md
@@ -1,0 +1,194 @@
+---
+name: project-onboarding-specialist
+description: Expert in research software project initialization, contributor onboarding, and knowledge transfer for open-source projects in any language. Scaffolds community health files, creates onboarding documentation, and prepares projects for handoff.
+color: blue
+model: inherit
+skills:
+  - community-health-files
+  - documentation-validation
+metadata:
+  expertise:
+    - Project initialization and scaffolding for any language
+    - Community health file creation (README, CONTRIBUTING, LICENSE, CODE_OF_CONDUCT, SECURITY, CITATION.cff)
+    - Contributor onboarding documentation
+    - Knowledge transfer and project handoff preparation
+    - Issue and PR template setup
+    - Language-agnostic project structure
+    - Research software engineering best practices
+    - Documentation gap analysis and auditing
+    - Open-source community standards (GitHub community profile)
+    - Academic citation metadata (CITATION.cff, DOI, ORCID)
+  use-cases:
+    - Setting up a new research software project with standard community health files
+    - Creating onboarding documentation for new team members or contributors
+    - Preparing a project for handoff to new maintainers
+    - Adding missing community health files to an existing project
+    - Scaffolding GitHub issue and PR templates
+    - Auditing project documentation completeness before release
+    - Writing onboarding guides for interdisciplinary research teams
+    - Creating handoff packages with status reports and knowledge transfer materials
+---
+
+You are an expert in research software project initialization, contributor onboarding, and knowledge transfer. You help research software teams set up projects in any language following open-source best practices, create comprehensive onboarding documentation, and prepare projects for smooth handoffs between team members.
+
+## Purpose
+
+Expert in the full project lifecycle for research software — from initial scaffolding with community health files, through contributor onboarding with clear documentation, to project handoff preparation ensuring knowledge is preserved. Deep understanding of what makes research software projects welcoming, maintainable, and sustainable across any language or framework.
+
+## Workflow Patterns
+
+**Project Initialization:**
+- Create project directory structure with community health files and templates
+- Generate community health files (README, CONTRIBUTING, LICENSE, CODE_OF_CONDUCT, SECURITY, CITATION.cff)
+- Set up issue templates (bug report, feature request) and PR template
+- Generate a language-appropriate .gitignore
+- Recommend the GitHub plugin for CI/CD setup and the containerization plugin for Dockerfiles
+
+**Contributor Onboarding:**
+- Analyze existing project to understand structure, conventions, and workflows
+- Generate onboarding guide covering:
+  - Project goals, scope, and stakeholders
+  - Development environment setup (step-by-step)
+  - Codebase navigation (key files, architecture, patterns)
+  - Development workflow (branching, PRs, reviews, CI)
+  - Domain knowledge (glossary, key algorithms, background reading)
+  - Key contacts and communication channels
+- Validate onboarding instructions by tracing through setup steps
+
+**Knowledge Transfer / Offboarding:**
+- Document institutional knowledge and undocumented decisions
+- Create comprehensive status report (active work, next steps, blockers)
+- Audit open issues, PRs, and experimental branches
+- Prepare handoff checklist (access, credentials, external partners)
+- Update documentation for long-term maintenance
+
+**Documentation Auditing:**
+- Check for presence and completeness of community health files
+- Validate that setup instructions are clear and functional
+- Identify documentation gaps and suggest improvements
+- Verify links, examples, and references are current
+
+## Constraints
+
+- **Always** check for existing files before creating new ones — don't overwrite without asking
+- **Default** to BSD-3-Clause license for research software projects unless instructed otherwise
+- **Always** include CITATION.cff for academic/research projects
+- **Never** include credentials, API keys, or secrets in generated files
+- **Always** use the `gh` CLI for GitHub operations when available
+- **Do not** assume specific organizational structure — ask about team size, funding model, and workflows
+- **Always** generate templates that can be customized, not rigid boilerplate
+- **Do not** create placeholder content — every generated file should be substantive and useful
+
+## Core Decision-Making Framework
+
+When approaching any project initialization or onboarding task:
+
+<thinking>
+1. **Assess Project Stage**: Is this a new project, existing project needing files, or handoff?
+2. **Understand Organization**: Who maintains this? Academic lab, research center, or open community?
+3. **Identify Gaps**: What community health files and documentation are missing?
+4. **Determine Audience**: Who are the contributors? Students, postdocs, professional engineers?
+5. **Choose Templates**: Which templates and standards are appropriate for this project type?
+6. **Plan Validation**: How will we verify the onboarding docs actually work?
+</thinking>
+
+## Key Preferences
+
+### Project Structure
+- Recommended project layout appropriate for the detected language/framework
+- Community health files in repository root
+- Issue templates in `.github/ISSUE_TEMPLATE/`
+- PR template in `.github/PULL_REQUEST_TEMPLATE.md`
+
+### Documentation Standards
+- README follows a consistent structure: badges, description, installation, quickstart, docs, contributing, citation, license
+- CONTRIBUTING includes development setup, code style, testing, PR process
+- All documentation written for the target audience (researchers, not just developers)
+
+### Onboarding Priorities
+- Development environment setup should work on first attempt
+- Architecture overview with visual diagrams where helpful
+- Glossary of domain-specific terms for interdisciplinary teams
+- Clear "first contribution" path for new contributors
+
+### Research Software Specifics
+- CITATION.cff for proper academic attribution
+- Data access and reproducibility instructions
+- Reference to relevant papers and methods
+- Clear distinction between stable API and experimental features
+
+## Behavioral Traits
+
+- Thorough: Checks for every standard community health file, not just the obvious ones
+- Inclusive: Creates documentation accessible to contributors of varying experience levels
+- Practical: Generates working templates, not theoretical guidelines
+- Proactive: Identifies missing files and documentation gaps before being asked
+- Respectful: Preserves existing content and conventions in the project
+
+## Response Approach
+
+### 1. Assess Current State
+<analysis>
+- Scan for existing community health files (README, CONTRIBUTING, LICENSE, etc.)
+- Check project structure (src layout, tests, docs)
+- Identify CI/CD configuration
+- Note any existing conventions or style choices
+</analysis>
+
+### 2. Identify Gaps
+<gap_analysis>
+- Missing community health files
+- Incomplete or outdated documentation
+- Missing templates (issues, PRs)
+- Absent onboarding materials
+- Missing CITATION.cff for academic projects
+</gap_analysis>
+
+### 3. Generate Content
+- Create missing files using templates adapted to the project
+- Customize templates with project-specific information
+- Ensure consistency with existing project conventions
+- Include substantive content, not placeholders
+
+### 4. Self-Review
+<self_review>
+- [ ] All standard community health files present
+- [ ] README has installation, quickstart, and contribution sections
+- [ ] CONTRIBUTING includes development setup that actually works
+- [ ] License is appropriate for the project (BSD-3-Clause default)
+- [ ] CITATION.cff included for research projects
+- [ ] Issue and PR templates are clear and useful
+- [ ] No credentials or secrets in generated content
+- [ ] Documentation is written for the target audience
+</self_review>
+
+### 5. Validate
+- Trace through setup instructions mentally or with tools
+- Check that links and references are valid
+- Verify generated YAML/JSON is syntactically correct
+- Confirm CITATION.cff follows the Citation File Format specification
+
+## Escalation Strategy
+
+**Unknown Project Type:**
+- Ask about the project's primary audience, funding model, and maintenance expectations
+- Request example projects they want to emulate
+
+**Conflicting Standards:**
+- Present options with trade-offs (e.g., MIT vs BSD-3-Clause for license)
+- Reference community standards for the relevant ecosystem
+
+**Large Existing Projects:**
+- Propose incremental improvements rather than wholesale restructuring
+- Prioritize the most impactful gaps first
+
+## Completion Criteria
+
+A task is considered complete when:
+
+- [ ] All requested community health files are created with substantive content
+- [ ] Generated files follow project conventions and research software best practices
+- [ ] Templates are customized to the specific project (not generic boilerplate)
+- [ ] Setup instructions have been validated or are clearly marked for testing
+- [ ] CITATION.cff is present for academic/research projects
+- [ ] User has been informed of any remaining gaps or recommended next steps

--- a/plugins/project-management/commands/project-handoff.md
+++ b/plugins/project-management/commands/project-handoff.md
@@ -1,0 +1,226 @@
+---
+name: project-handoff
+description: Assess project readiness for handoff to new maintainers with a comprehensive health check
+user-invocable: true
+---
+
+# Project Handoff Command
+
+When this command is invoked, perform a comprehensive project health assessment to determine if the project is ready for handoff to new maintainers. Generate a detailed readiness report with pass/fail/warning for each criterion.
+
+## Input Handling
+
+**If argument provided** (e.g., `/project-handoff` or `/project-handoff path/to/project`):
+- If a path is provided, assess the project at that path
+- If no path, assess the current working directory
+
+**If run without context:**
+- Assess the current working directory as the project root
+- Detect the repository from git configuration
+
+## Handoff Assessment Process
+
+### Step 1: Community Health Files Check
+
+Check for the presence and completeness of standard community health files:
+
+| File | Status | Criteria |
+|------|--------|----------|
+| README.md | Required | Must exist, >50 lines, has installation and usage sections |
+| LICENSE | Required | Must exist, recognized license text |
+| CONTRIBUTING.md | Required | Must exist, has development setup instructions |
+| CODE_OF_CONDUCT.md | Recommended | Should exist for community projects |
+| SECURITY.md | Recommended | Should exist with reporting instructions |
+| CHANGELOG.md | Recommended | Should exist, has recent entries |
+| CITATION.cff | Recommended | Should exist for academic/research projects |
+
+For each file:
+- **PASS**: File exists and meets criteria
+- **WARN**: File exists but is incomplete or minimal
+- **FAIL**: File is missing
+
+### Step 2: Documentation Quality Check
+
+Assess documentation completeness:
+
+- **Installation instructions**: Do they exist in README or dedicated docs?
+- **Quickstart / Usage**: Is there a getting-started guide?
+- **API Reference**: Is there auto-generated or hand-written API documentation?
+- **Development setup**: Can a new developer set up their environment from docs?
+- **Testing guide**: Are testing instructions documented?
+- **Architecture overview**: Is there a high-level description of the codebase?
+
+Read the README and CONTRIBUTING files to verify these sections exist.
+
+### Step 3: CI/CD Status Check
+
+Use `gh` to check CI/CD health:
+
+```bash
+# Check for workflow files
+ls .github/workflows/*.yml 2>/dev/null
+
+# Check recent CI runs on default branch
+gh run list --branch main --limit 5 --json conclusion,name,createdAt
+
+# Check if branch protection is configured
+gh api repos/{owner}/{repo}/branches/main/protection 2>/dev/null
+```
+
+Assess:
+- **CI workflows exist**: Are there GitHub Actions workflow files?
+- **CI is passing**: Did the most recent run on the default branch succeed?
+- **Branch protection**: Is the default branch protected?
+
+### Step 4: Test Suite Assessment
+
+Check the test suite:
+
+```bash
+# Check for test files (look for common test directory patterns)
+ls tests/ test/ spec/ 2>/dev/null
+
+# Check for test framework configuration in project config files
+# (e.g., pyproject.toml, package.json, Cargo.toml, Makefile, etc.)
+
+# Check recent test coverage (if available)
+```
+
+Assess:
+- **Tests exist**: Are there test files?
+- **Test framework configured**: Is the project's test framework configured?
+- **Coverage reporting**: Is coverage measurement set up?
+
+### Step 5: Dependency and Security Check
+
+```bash
+# Check for dependency specification files
+# (pyproject.toml, Cargo.toml, package.json, go.mod, DESCRIPTION, etc.)
+ls pyproject.toml Cargo.toml package.json go.mod DESCRIPTION pixi.toml environment.yml requirements.txt 2>/dev/null
+
+# Check for Dependabot or Renovate configuration
+ls .github/dependabot.yml .renovaterc.json 2>/dev/null
+
+# Check for security alerts (if accessible)
+gh api repos/{owner}/{repo}/vulnerability-alerts 2>/dev/null
+```
+
+Assess:
+- **Dependencies specified**: Are dependencies locked/pinned?
+- **Automated updates**: Is Dependabot or Renovate configured?
+- **Security alerts**: Are there open security vulnerabilities?
+
+### Step 6: Project Activity and Open Work
+
+```bash
+# Check for open issues
+gh issue list --state open --json number,title,labels --limit 50
+
+# Check for open PRs
+gh pr list --state open --json number,title,labels --limit 20
+
+# Check for stale branches
+git branch -r --sort=-committerdate | head -20
+
+# Check last commit date
+git log -1 --format=%ci
+```
+
+Assess:
+- **Open issues triaged**: Are open issues labeled and organized?
+- **Open PRs addressed**: Are there stale PRs that need resolution?
+- **Stale branches**: Are there experimental branches that should be cleaned up?
+- **Recent activity**: When was the last commit?
+
+### Step 7: Generate Handoff Readiness Report
+
+Present the assessment as a structured report:
+
+```
+## Project Handoff Readiness Report
+
+**Project:** <project-name>
+**Date:** <today>
+**Assessed by:** AI Assistant
+
+### Overall Status: READY / NEEDS WORK / NOT READY
+
+---
+
+### Community Health Files
+| File | Status | Notes |
+|------|--------|-------|
+| README.md | ✅ PASS | 120 lines, has installation and usage |
+| LICENSE | ✅ PASS | BSD-3-Clause |
+| CONTRIBUTING.md | ⚠️ WARN | Exists but missing development setup |
+| CODE_OF_CONDUCT.md | ✅ PASS | Contributor Covenant v2.1 |
+| SECURITY.md | ❌ FAIL | Missing |
+| CHANGELOG.md | ⚠️ WARN | Exists but no entries since v0.3.0 |
+| CITATION.cff | ❌ FAIL | Missing (recommended for research software) |
+
+### Documentation
+| Area | Status | Notes |
+|------|--------|-------|
+| Installation | ✅ PASS | Clear pip install instructions in README |
+| Usage / Quickstart | ⚠️ WARN | Basic example but no tutorial |
+| API Reference | ❌ FAIL | No API documentation found |
+| Development Setup | ❌ FAIL | CONTRIBUTING.md lacks setup instructions |
+| Testing Guide | ✅ PASS | Documented in CONTRIBUTING.md |
+| Architecture Overview | ❌ FAIL | No architecture documentation |
+
+### CI/CD
+| Check | Status | Notes |
+|-------|--------|-------|
+| Workflows exist | ✅ PASS | ci.yml, docs.yml |
+| CI passing | ✅ PASS | Last 5 runs all passed |
+| Branch protection | ⚠️ WARN | Not configured |
+
+### Test Suite
+| Check | Status | Notes |
+|-------|--------|-------|
+| Tests exist | ✅ PASS | 42 test files found |
+| Framework configured | ✅ PASS | pytest in pyproject.toml |
+| Coverage reporting | ⚠️ WARN | Not configured |
+
+### Dependencies & Security
+| Check | Status | Notes |
+|-------|--------|-------|
+| Dependencies specified | ✅ PASS | pyproject.toml with pinned deps |
+| Automated updates | ❌ FAIL | No Dependabot configuration |
+| Security alerts | ⚠️ WARN | 2 moderate alerts |
+
+### Project Activity
+| Check | Status | Notes |
+|-------|--------|-------|
+| Open issues triaged | ⚠️ WARN | 15 open, 8 unlabeled |
+| Open PRs addressed | ✅ PASS | 2 open, both recent |
+| Stale branches | ⚠️ WARN | 5 branches >6 months old |
+
+---
+
+### Summary
+- **Critical Issues (FAIL):** <count> — Must fix before handoff
+- **Warnings (WARN):** <count> — Should fix before handoff
+- **Passing (PASS):** <count>
+
+### Priority Actions Before Handoff
+1. [CRITICAL] Create SECURITY.md with vulnerability reporting instructions
+2. [CRITICAL] Add development setup instructions to CONTRIBUTING.md
+3. [CRITICAL] Generate API documentation
+4. [IMPORTANT] Create CITATION.cff for academic attribution
+5. [IMPORTANT] Configure Dependabot for automated dependency updates
+6. [IMPORTANT] Triage and label all open issues
+7. [RECOMMENDED] Set up branch protection on default branch
+8. [RECOMMENDED] Add coverage reporting to CI
+9. [RECOMMENDED] Clean up stale branches
+10. [RECOMMENDED] Update CHANGELOG.md with recent changes
+```
+
+## Important Notes
+
+- **Read-only assessment**: This command only checks and reports — it does not modify any files
+- **Use `/validate-project-handoff`** for the complementary step of actually testing that setup instructions work
+- **Use `/setup-project`** or the `project-onboarding-specialist` agent to fix identified gaps
+- **Be specific**: Every FAIL and WARN should include what's missing and what to do about it
+- **Consider the audience**: New maintainers need to understand the project quickly — gaps in documentation are critical
+- **Reference the `documentation-validation` skill** for validation tool recommendations

--- a/plugins/project-management/commands/setup-project.md
+++ b/plugins/project-management/commands/setup-project.md
@@ -1,0 +1,158 @@
+---
+name: setup-project
+description: Scaffold a new project with community health files and standard structure for any language
+user-invocable: true
+---
+
+# Setup Project Command
+
+When this command is invoked, initialize a new research software project with community health files and standard open-source infrastructure.
+
+## Input Handling
+
+**If argument provided** (e.g., `/setup-project my-climate-tool`):
+- Use the argument as the project name
+- Proceed to project setup
+
+**If no argument provided:**
+- Ask the user:
+  ```
+  What is the name of your new project?
+
+  I'll create a project with:
+  - Community health files (README, CONTRIBUTING, LICENSE, CODE_OF_CONDUCT, SECURITY, CITATION.cff)
+  - Issue and PR templates
+  - .gitignore for your language
+
+  Optionally:
+  - Set up CI/CD (requires the GitHub plugin)
+  - Add a Dockerfile (requires the containerization plugin)
+
+  Please provide a project name (kebab-case recommended, e.g., `climate-analysis-tool`).
+  ```
+- WAIT for the user's response before proceeding
+
+## Information Gathering
+
+Before creating files, ask the user for essential configuration (use defaults if they want to proceed quickly):
+
+1. **Brief project description** (one sentence)
+2. **License** — Default: BSD-3-Clause (common for research software). Options: MIT, Apache-2.0, GPL-3.0
+3. **Primary language** — Python, R, Julia, Rust, Go, Node.js, C/C++, Other
+4. **Author/organization name** — Default: detect from `gh` config or git config
+
+If the user says "use defaults" or "just create it", proceed with all defaults.
+
+## Project Scaffolding Steps
+
+### Step 1: Create Directory Structure
+
+Create the standard project scaffold with universal infrastructure files:
+
+```
+<project-name>/
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug_report.yml
+│   │   └── feature_request.yml
+│   └── PULL_REQUEST_TEMPLATE.md
+├── README.md
+├── CONTRIBUTING.md
+├── LICENSE
+├── CODE_OF_CONDUCT.md
+├── SECURITY.md
+├── CITATION.cff
+└── .gitignore
+```
+
+Note: Language-specific directories (src/, tests/, docs/, lib/, etc.) and project configuration files (pyproject.toml, Cargo.toml, package.json, etc.) should be created using language-specific tooling. This command scaffolds the universal project infrastructure that every project needs regardless of language.
+
+### Step 2: Generate Community Health Files
+
+Use the `community-health-files` skill as reference for content and templates.
+
+- **README.md**: Use the README template from `community-health-files` skill assets. Customize with project name, description, and badge placeholders appropriate for the chosen language.
+- **CONTRIBUTING.md**: Use the CONTRIBUTING template. Customize with project name and language-appropriate development setup guidance.
+- **LICENSE**: Generate the selected license with current year and author name.
+- **CODE_OF_CONDUCT.md**: Use Contributor Covenant v2.1 template.
+- **SECURITY.md**: Use SECURITY template with project name.
+- **CITATION.cff**: Use CITATION template. Fill in project name, description, author, and current date.
+
+### Step 3: Generate Issue and PR Templates
+
+- **Bug report** (`bug_report.yml`): GitHub issue form with description, reproduction steps, expected/actual behavior, environment info (language-neutral).
+- **Feature request** (`feature_request.yml`): GitHub issue form with problem statement, proposed solution, alternatives considered.
+- **PR template** (`PULL_REQUEST_TEMPLATE.md`): Checklist with description, type of change, testing done, and documentation updated.
+
+### Step 4: Language-Specific Configuration (User Responsibility)
+
+The project scaffold includes community health files and GitHub templates. Language-specific project configuration should be created using the appropriate tooling:
+
+- **Python:** `pip install hatch && hatch new` or configure `pyproject.toml` manually
+- **Rust:** `cargo init`
+- **Node.js:** `npm init`
+- **R:** `usethis::create_package()`
+- **Go:** `go mod init`
+- **Julia:** `Pkg.generate()`
+- **C/C++:** Create a `CMakeLists.txt` or `Makefile` as appropriate
+
+This command focuses on the universal project infrastructure that every project needs regardless of language.
+
+### Step 5: CI/CD Setup (Optional — Requires GitHub Plugin)
+
+If you have the GitHub plugin installed, run `/ci-setup` to generate GitHub Actions CI/CD workflows tailored to your project's language and tooling.
+
+### Step 6: Pre-commit Hooks (Optional — Requires GitHub Plugin)
+
+If you have the GitHub plugin installed, it can configure pre-commit hooks appropriate for your project's language.
+
+### Step 7: Generate .gitignore
+
+Generate a `.gitignore` based on the project's primary language. Include universal entries:
+
+- `.DS_Store`, `Thumbs.db`
+- `.env`, `*.log`
+- Editor files: `.vscode/`, `.idea/`
+
+Add language-specific patterns based on the selected language (e.g., `__pycache__/` for Python, `target/` for Rust, `node_modules/` for Node.js, `.Rhistory` for R).
+
+## Output Summary
+
+After creating all files, present a summary:
+
+```
+## Project Created: <project-name>
+
+### Files Created:
+- README.md — Project description, installation, quickstart
+- CONTRIBUTING.md — Contribution guidelines with development setup
+- LICENSE — <license-type>
+- CODE_OF_CONDUCT.md — Contributor Covenant v2.1
+- SECURITY.md — Security reporting policy
+- CITATION.cff — Academic citation metadata
+- .github/ISSUE_TEMPLATE/bug_report.yml — Bug report form
+- .github/ISSUE_TEMPLATE/feature_request.yml — Feature request form
+- .github/PULL_REQUEST_TEMPLATE.md — PR checklist
+- .gitignore — <language> .gitignore
+
+### Next Steps:
+1. `cd <project-name>`
+2. `git init && git add . && git commit -m "Initial project scaffold"`
+3. `gh repo create <project-name> --public --source=. --push`
+4. Set up language-specific project configuration (see Step 4 above)
+5. (Optional) Install GitHub plugin and run `/ci-setup` for CI/CD workflows
+
+### Customize:
+- Update README.md with detailed project description
+- Add language-specific configuration files
+- Update CITATION.cff with all authors and ORCIDs
+- Customize issue templates for your project's needs
+```
+
+## Important Notes
+
+- **Check before overwriting**: If any files already exist in the target directory, warn the user and ask before overwriting.
+- **Validate YAML**: Ensure all generated configuration files are syntactically valid.
+- **Use templates**: Reference the `community-health-files` skill asset templates for community health files.
+- **Respect user choices**: Honor the license and language the user specified.
+- **Universal infrastructure only**: This command scaffolds community health files and GitHub templates. Language-specific project configuration is the user's responsibility.

--- a/plugins/project-management/commands/validate-project-handoff.md
+++ b/plugins/project-management/commands/validate-project-handoff.md
@@ -1,0 +1,199 @@
+---
+name: validate-project-handoff
+description: Validate project handoff by testing that setup instructions, documentation, and workflows actually work
+user-invocable: true
+---
+
+# Validate Project Handoff Command
+
+When this command is invoked, actively test that the project's documentation and setup instructions actually work by following them step-by-step. This is the complementary command to `/project-handoff` — while that command checks for the *presence* of documentation, this command tests that the documentation is *correct and functional*.
+
+## Input Handling
+
+**If argument provided** (e.g., `/validate-project-handoff` or `/validate-project-handoff path/to/project`):
+- If a path is provided, validate the project at that path
+- If no path, validate the current working directory
+
+**If no context:**
+- Validate the current working directory
+- Detect the repository from git configuration
+
+## Validation Process
+
+### Step 1: Read All Documentation
+
+Read the following files completely:
+
+1. `README.md` — Primary setup and usage instructions
+2. `CONTRIBUTING.md` — Development setup instructions
+3. `docs/` directory — Any additional documentation
+4. Project configuration file (pyproject.toml, Cargo.toml, package.json, etc.) — Dependency specification
+
+Identify all instruction blocks that contain commands a user would run.
+
+### Step 2: Validate Installation Instructions
+
+Trace through the installation instructions documented in README.md:
+
+**For each installation method documented (e.g., pip, conda, pixi, from source):**
+
+1. Read the exact commands listed in the documentation
+2. Check if prerequisites are mentioned (Python version, system packages)
+3. Verify the package name is correct for the documented install command
+4. If "from source" instructions exist, verify they reference the correct repository URL
+5. Check that the documented Python version requirement matches `pyproject.toml`
+
+**Record for each method:**
+- Commands documented
+- Whether commands are syntactically correct
+- Whether prerequisites are listed
+- Any ambiguities or missing steps
+
+### Step 3: Validate Development Setup Instructions
+
+Trace through the development setup in CONTRIBUTING.md:
+
+1. Read fork/clone instructions
+2. Check that the documented environment setup commands reference correct files
+3. Verify that dependency installation commands match the project's package manager
+4. Check that pre-commit installation is documented (if `.pre-commit-config.yaml` exists)
+5. Verify test running commands match the configured test framework
+
+**Check for common issues:**
+- References to files that don't exist (e.g., `requirements-dev.txt` when only `pyproject.toml` exists)
+- Outdated package manager references (e.g., documents `pip` but project uses `pixi`)
+- Missing steps between "clone repo" and "run tests"
+- Undocumented system dependencies
+
+### Step 4: Validate Code Examples
+
+If the README or docs contain code examples:
+
+1. Read each code example
+2. Check if code examples reference modules, functions, or types that exist in the codebase
+3. Verify that example function calls reference functions that exist in the codebase
+4. Check that example output (if shown) is plausible
+
+Use `grep` and file reading to verify that referenced modules, classes, and functions exist.
+
+### Step 5: Validate CI Configuration
+
+Check that CI configuration matches the documented development workflow:
+
+1. Read `.github/workflows/*.yml`
+2. Verify CI language/runtime versions match the documented requirements
+3. Check that CI test commands match the documented test commands
+4. Verify that CI uses the same build tools and package managers documented for contributors
+
+### Step 6: Check for Broken Links
+
+Scan documentation files for URLs and verify them:
+
+1. Extract all URLs from README.md, CONTRIBUTING.md, and docs/
+2. Categorize: internal links (relative paths), external links (http/https)
+3. For internal links, verify the target file exists
+4. For external links, note them for manual verification (don't fetch automatically)
+
+### Step 7: Validate CITATION.cff
+
+If `CITATION.cff` exists:
+
+1. Check that it has required fields (cff-version, message, title, authors, type)
+2. Verify the version matches the project version
+3. Check that the repository-code URL is correct
+4. Validate date format (YYYY-MM-DD)
+
+### Step 8: Generate Validation Report
+
+Present the validation results:
+
+```
+## Project Handoff Validation Report
+
+**Project:** <project-name>
+**Date:** <today>
+**Validated by:** AI Assistant
+
+### Overall Status: VALID / ISSUES FOUND / CRITICAL ISSUES
+
+---
+
+### Installation Instructions
+| Method | Status | Issues |
+|--------|--------|--------|
+| pip install | ✅ VALID | Commands are correct |
+| From source | ⚠️ ISSUE | Missing step: `pip install -e .` after clone |
+| conda | ❌ BROKEN | References `conda-forge` channel but package not published there |
+
+**Details:**
+- README line 42: `pip install my-package` — Package name verified on PyPI ✅
+- README line 55: Clone instructions reference correct repository URL ✅
+- README line 58: Missing `cd my-package` between clone and install ❌
+
+### Development Setup
+| Step | Status | Issues |
+|------|--------|--------|
+| Fork & Clone | ✅ VALID | Clear instructions |
+| Create environment | ⚠️ ISSUE | Documents `conda` but project uses `pixi` |
+| Install dependencies | ❌ BROKEN | References `requirements-dev.txt` which doesn't exist |
+| Run tests | ✅ VALID | `pytest` command matches pyproject.toml config |
+| Pre-commit | ⚠️ ISSUE | .pre-commit-config.yaml exists but setup not documented |
+
+**Details:**
+- CONTRIBUTING.md line 23: References `requirements-dev.txt` — file not found ❌
+- CONTRIBUTING.md line 31: `pytest tests/` — command is correct ✅
+- CONTRIBUTING.md line 35: No mention of `pre-commit install` ⚠️
+
+### Code Examples
+| Example | Location | Status | Issue |
+|---------|----------|--------|-------|
+| Basic usage | README:72-85 | ✅ VALID | Imports match package structure |
+| Advanced | README:90-110 | ❌ BROKEN | `from mypackage.utils import deprecated_func` — function removed in v0.4 |
+
+### CI Configuration
+| Check | Status | Issue |
+|-------|--------|-------|
+| Python versions match | ⚠️ MISMATCH | CI tests 3.10-3.12, pyproject says >=3.10, docs say 3.11+ |
+| Test command matches | ✅ VALID | Both use `pytest` |
+| Package manager matches | ❌ MISMATCH | CI uses pixi, CONTRIBUTING documents conda |
+
+### Internal Links
+| Link | File | Status |
+|------|------|--------|
+| `docs/api.md` | README:120 | ❌ BROKEN | File does not exist |
+| `CONTRIBUTING.md` | README:130 | ✅ VALID | File exists |
+| `LICENSE` | README:135 | ✅ VALID | File exists |
+
+### CITATION.cff
+| Field | Status | Issue |
+|-------|--------|-------|
+| Required fields | ✅ VALID | All present |
+| Version match | ⚠️ MISMATCH | CITATION says 0.3.0, pyproject says 0.4.1 |
+| Repository URL | ✅ VALID | Matches git remote |
+
+---
+
+### Summary
+- **Critical Issues:** <count> — Documentation actively misleads users
+- **Issues:** <count> — Documentation is incomplete or inconsistent
+- **Valid:** <count> — Documentation is correct and functional
+
+### Priority Fixes
+1. [CRITICAL] CONTRIBUTING.md:23 — Replace `requirements-dev.txt` reference with `pip install -e ".[dev]"`
+2. [CRITICAL] README:90-110 — Update code example: `deprecated_func` was removed in v0.4
+3. [IMPORTANT] CONTRIBUTING.md — Add `pre-commit install` step after environment setup
+4. [IMPORTANT] README:55 — Add `cd my-package` step after clone command
+5. [IMPORTANT] Sync Python version requirements across README, pyproject.toml, and CI config
+6. [IMPORTANT] Update CITATION.cff version to match current release
+7. [RECOMMENDED] Remove broken link to `docs/api.md` or create the file
+```
+
+## Important Notes
+
+- **Read-only validation**: This command reads and analyzes but does NOT modify any files
+- **Be specific**: Every issue must reference the exact file and line number
+- **Trace instructions literally**: Follow documentation as a new user would — don't fill in gaps with assumptions
+- **Distinguish severity**: "Actively misleading" (CRITICAL) vs "missing information" (IMPORTANT) vs "could be better" (RECOMMENDED)
+- **Complement `/project-handoff`**: That command checks presence; this command checks correctness
+- **Use the `documentation-validation` skill** for recommendations on automated validation tooling
+- **Suggest fixes**: For each issue found, suggest the specific correction

--- a/plugins/project-management/skills/community-health-files/SKILL.md
+++ b/plugins/project-management/skills/community-health-files/SKILL.md
@@ -1,0 +1,652 @@
+---
+name: community-health-files
+description: Templates and guidance for creating community health files (README, CONTRIBUTING, LICENSE, CODE_OF_CONDUCT, SECURITY, CITATION.cff, issue/PR templates) for open-source research software projects in any language.
+metadata:
+  references:
+    - references/LICENSE_GUIDE.md
+    - references/CITATION_FORMAT.md
+    - references/GITHUB_TEMPLATES.md
+  assets:
+    - assets/README-template.md
+    - assets/CONTRIBUTING-template.md
+    - assets/CODE_OF_CONDUCT-template.md
+    - assets/SECURITY-template.md
+    - assets/CITATION-template.cff
+---
+
+# Community Health Files for Research Software Projects
+
+A comprehensive guide to creating and maintaining community health files for open-source research software projects. Community health files define how contributors interact with your project, set expectations for behavior, and establish processes for contributions, security reporting, and citation. This skill follows GitHub community standards and adds specific guidance for scientific software and research engineering contexts.
+
+## Quick Reference Card
+
+**Community Health Files Checklist:**
+
+| File | Purpose | Priority | Location |
+|------|---------|----------|----------|
+| `README.md` | Project overview, installation, usage | Required | Root |
+| `LICENSE` | Legal terms for use and distribution | Required | Root |
+| `CONTRIBUTING.md` | How to contribute to the project | Required | Root or `.github/` |
+| `CODE_OF_CONDUCT.md` | Community behavior standards | Required | Root or `.github/` |
+| `SECURITY.md` | How to report vulnerabilities | Recommended | Root or `.github/` |
+| `SUPPORT.md` | How to get help | Recommended | Root or `.github/` |
+| `CITATION.cff` | How to cite the software | Recommended | Root |
+| `FUNDING.yml` | Sponsorship and funding links | Optional | `.github/` |
+| `.github/ISSUE_TEMPLATE/` | Structured issue reporting | Recommended | `.github/` |
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR checklist and guidelines | Recommended | `.github/` |
+| `CHANGELOG.md` | Record of notable changes | Recommended | Root |
+| `GOVERNANCE.md` | Decision-making and leadership | Optional | Root or `.github/` |
+
+**Quick Setup Commands:**
+
+```bash
+# Create standard community files from templates
+mkdir -p .github/ISSUE_TEMPLATE
+
+# Files in project root
+touch README.md LICENSE CONTRIBUTING.md CODE_OF_CONDUCT.md
+touch SECURITY.md SUPPORT.md CITATION.cff CHANGELOG.md
+
+# Files in .github/
+touch .github/FUNDING.yml
+touch .github/PULL_REQUEST_TEMPLATE.md
+touch .github/ISSUE_TEMPLATE/bug_report.yml
+touch .github/ISSUE_TEMPLATE/feature_request.yml
+touch .github/ISSUE_TEMPLATE/config.yml
+```
+
+**GitHub Community Profile:**
+GitHub automatically detects these files and shows a "Community Standards" checklist at `https://github.com/<owner>/<repo>/community`. Completing all recommended files earns a full community profile score.
+
+## When to Use This Skill
+
+- Setting up a new open-source research software project from scratch
+- Improving the community health profile of an existing project
+- Creating standardized templates for an organization's repositories
+- Adding citation metadata so researchers can properly cite your software
+- Establishing contribution guidelines for a research software project
+- Setting up security disclosure policies for scientific tools
+- Creating issue and PR templates for consistent project management
+- Preparing a research codebase for public release or peer review
+- Setting up organization-level defaults in a `.github` repository
+- Migrating from informal project management to structured community standards
+
+## Standard Community Health Files
+
+### 1. README.md
+
+The README is the front door of your project. It is the first file most visitors read and serves as the primary documentation entry point.
+
+**What it should contain:**
+
+- Project name, logo, and badges (CI status, coverage, PyPI version, license)
+- One-paragraph description of what the project does and why it exists
+- Installation instructions (pip, conda, from source)
+- Quick start example showing the most common use case
+- Links to full documentation
+- How to cite the project (brief, with link to CITATION.cff)
+- Contributing link and license summary
+- Acknowledgments and funding sources
+
+**Best practices for scientific software:**
+
+- Include a DOI badge if the software is archived on Zenodo
+- Show a scientific use case in the quick start, not just a trivial example
+- Link to any associated publications or preprints
+- Mention the scientific domain and target audience clearly
+- Include a "Related Projects" section to help users find alternatives
+
+See [assets/README-template.md](assets/README-template.md) for a complete template.
+
+### 2. LICENSE
+
+The LICENSE file defines the legal terms under which others can use, modify, and distribute your software. Choosing the right license is critical for scientific software because it affects whether others can use your code in their research.
+
+**Common licenses for research software projects:**
+
+| License | Type | Key Feature | Used By |
+|---------|------|-------------|---------|
+| BSD 3-Clause | Permissive | Simple, allows commercial use | NumPy, SciPy, scikit-learn |
+| MIT | Permissive | Very simple, minimal restrictions | Many Node.js and small projects |
+| Apache 2.0 | Permissive | Patent protection clause | TensorFlow, Arrow, many Rust/Go projects |
+| GPL 3.0 | Copyleft | Derivative works must be open source | Some research tools |
+| LGPL 3.0 | Weak copyleft | Libraries can be used in proprietary code | Some scientific libraries |
+
+**Recommendations for research software:**
+
+- **BSD 3-Clause** is the most common choice in the research software ecosystem
+- Apache-2.0 is common in Rust and Go projects; MIT is prevalent in the Node.js ecosystem
+- Permissive licenses maximize adoption and reuse in research
+- Always include the full license text, not just a reference
+- Use SPDX identifiers in your project configuration (`pyproject.toml`, `Cargo.toml`, `package.json`, etc.)
+- If your project has multiple contributors, consider a contributor license agreement (CLA)
+
+### 3. CONTRIBUTING.md
+
+The CONTRIBUTING file tells potential contributors how to participate in your project. Clear contribution guidelines reduce friction and encourage community involvement.
+
+**Key sections:**
+
+- How to report bugs (link to issue template)
+- How to suggest enhancements
+- Development environment setup (clone, install, test)
+- Code style guidelines and linting tools
+- Testing requirements (what tests to write, how to run them)
+- Pull request process (branch naming, review expectations, CI checks)
+- Commit message conventions
+- Documentation requirements
+- Communication channels (mailing list, Slack, Discourse, GitHub Discussions)
+
+**Best practices for scientific software:**
+
+- Include instructions for setting up a development environment with scientific dependencies
+- Mention how to run the full test suite including slow or integration tests
+- Describe how to add new algorithms or scientific functionality
+- Explain how to contribute to documentation, especially API docs and tutorials
+- Note any domain expertise needed for reviewing certain types of changes
+- Reference the code of conduct prominently
+
+See [assets/CONTRIBUTING-template.md](assets/CONTRIBUTING-template.md) for a complete template.
+
+### 4. CODE_OF_CONDUCT.md
+
+The Code of Conduct establishes community behavior standards and provides a framework for addressing unacceptable behavior. It signals that your project is welcoming and inclusive.
+
+**Recommended standard: Contributor Covenant v2.1**
+
+The Contributor Covenant is the most widely adopted code of conduct in open source. It is used by thousands of projects across many language ecosystems including Python, Rust, Go, and JavaScript.
+
+**Key elements:**
+
+- Pledge to make participation harassment-free
+- Examples of positive and negative behavior
+- Enforcement responsibilities and scope
+- Reporting mechanism with contact information
+- Consequence ladder (correction, warning, temporary ban, permanent ban)
+
+**Best practices for scientific software:**
+
+- Adapt the code of conduct for academic and research contexts
+- Include guidelines about respectful scientific discourse and disagreement
+- Name specific enforcement contacts (not just a generic email)
+- Connect to your institution's policies if applicable
+- Review and update annually
+
+See [assets/CODE_OF_CONDUCT-template.md](assets/CODE_OF_CONDUCT-template.md) for a complete template.
+
+### 5. SECURITY.md
+
+The SECURITY policy tells users and researchers how to responsibly disclose security vulnerabilities. Even scientific software can have security implications, particularly tools that handle data, run on shared infrastructure, or interact with external services.
+
+**Key sections:**
+
+- Supported versions (which versions receive security updates)
+- How to report a vulnerability (private channel, not public issues)
+- What information to include in a report
+- Expected response timeline
+- Disclosure policy and coordination
+- Scope of security concerns
+
+**Best practices for scientific software:**
+
+- Acknowledge that data integrity is a security concern for research tools
+- Mention any compliance requirements (HIPAA, FERPA, export controls)
+- Provide a dedicated security email or use GitHub's private vulnerability reporting
+- Commit to a reasonable response timeline (e.g., 48 hours for acknowledgment)
+- Credit reporters in security advisories (with their permission)
+
+See [assets/SECURITY-template.md](assets/SECURITY-template.md) for a complete template.
+
+### 6. SUPPORT.md
+
+The SUPPORT file tells users where and how to get help. It reduces noise in issue trackers by directing questions to appropriate channels.
+
+**Recommended contents:**
+
+```markdown
+# Getting Help
+
+## Documentation
+- Full documentation: https://my-project.readthedocs.io
+- API reference: https://my-project.readthedocs.io/en/latest/api/
+- Tutorials: https://my-project.readthedocs.io/en/latest/tutorials/
+
+## Asking Questions
+- **GitHub Discussions**: For general questions and community discussion
+- **Stack Overflow**: Tag your question with `my-project`
+- **Mailing list**: dev@my-project.org
+
+## Reporting Bugs
+- Use the [bug report template](https://github.com/org/repo/issues/new?template=bug_report.yml)
+- Include a minimal reproducible example
+- Include your environment details (OS, Python version, package versions)
+
+## Feature Requests
+- Use the [feature request template](https://github.com/org/repo/issues/new?template=feature_request.yml)
+
+## Security Issues
+- See [SECURITY.md](SECURITY.md) for reporting vulnerabilities
+- Do NOT file security issues as public GitHub issues
+```
+
+### 7. FUNDING.yml
+
+The FUNDING file enables the "Sponsor" button on your GitHub repository. Place it at `.github/FUNDING.yml`.
+
+**Example for scientific projects:**
+
+```yaml
+# .github/FUNDING.yml
+github: [maintainer-username]
+open_collective: project-name
+custom:
+  - https://numfocus.org/donate-to-project
+  - https://your-institution.edu/donate
+```
+
+**Supported platforms:**
+
+- `github` - GitHub Sponsors
+- `open_collective` - Open Collective
+- `ko_fi` - Ko-fi
+- `tidelift` - Tidelift
+- `community_bridge` - LFX Mentorship
+- `custom` - Up to 4 custom URLs
+
+### 8. CHANGELOG.md
+
+A changelog records all notable changes to the project, organized by version. It helps users understand what changed between releases and whether they need to update.
+
+**Recommended format (Keep a Changelog):**
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- New spectral analysis function `compute_power_spectrum()`
+
+### Changed
+- Improved performance of `fit_model()` by 3x
+
+### Fixed
+- Fixed incorrect unit conversion in `transform_coordinates()`
+
+## [1.0.0] - 2025-01-15
+
+### Added
+- Initial release with core analysis functions
+- Documentation and tutorials
+- Full test coverage
+```
+
+**Categories:** Added, Changed, Deprecated, Removed, Fixed, Security
+
+## The .github Organization-Level Defaults Pattern
+
+GitHub supports organization-level default community health files. When a repository does not have its own version of a file, GitHub falls back to the organization's `.github` repository.
+
+**How it works:**
+
+1. Create a repository named `.github` in your organization (e.g., `org-name/.github`)
+2. Place community health files in the root or in a `profile/` directory
+3. These files serve as defaults for all repositories in the organization
+
+**Supported files for organization defaults:**
+
+- `CODE_OF_CONDUCT.md`
+- `CONTRIBUTING.md`
+- `FUNDING.yml` (in `.github/` directory)
+- `GOVERNANCE.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+- `ISSUE_TEMPLATE/` and `PULL_REQUEST_TEMPLATE.md`
+
+**Files NOT supported as organization defaults:**
+
+- `README.md` (must be per-repository)
+- `LICENSE` (must be per-repository)
+- `CITATION.cff` (must be per-repository)
+
+**Directory structure for an organization `.github` repo:**
+
+```
+.github/
+├── profile/
+│   └── README.md          # Organization profile (shown on org page)
+├── CODE_OF_CONDUCT.md     # Default for all repos
+├── CONTRIBUTING.md         # Default for all repos
+├── SECURITY.md             # Default for all repos
+├── SUPPORT.md              # Default for all repos
+├── FUNDING.yml             # Default funding links
+├── GOVERNANCE.md           # Default governance
+├── ISSUE_TEMPLATE/
+│   ├── bug_report.yml      # Default bug report template
+│   ├── feature_request.yml # Default feature request template
+│   └── config.yml          # Issue template chooser config
+└── PULL_REQUEST_TEMPLATE.md
+```
+
+**Best practice:** Define common standards at the organization level and override only when a specific project has unique requirements.
+
+> **Note:** The GitHub plugin provides deeper guidance on organization-level defaults and platform mechanics.
+
+## CITATION.cff for Academic Projects
+
+The Citation File Format (CFF) is a human- and machine-readable file format that provides citation metadata for software. GitHub natively parses `CITATION.cff` and displays a "Cite this repository" button.
+
+**Why it matters for scientific software:**
+
+- Software citation is increasingly recognized as essential for reproducible research
+- Journals and funding agencies now expect proper software citation
+- CITATION.cff integrates with Zenodo, Zotero, and other reference managers
+- GitHub renders a formatted citation with APA and BibTeX export options
+
+**Required fields:**
+
+```yaml
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "My Scientific Package"
+authors:
+  - family-names: "Smith"
+    given-names: "Jane"
+    orcid: "https://orcid.org/0000-0000-0000-0000"
+type: software
+```
+
+**Recommended additional fields:**
+
+```yaml
+version: "1.0.0"
+date-released: "2025-01-15"
+doi: "10.5281/zenodo.1234567"
+license: "BSD-3-Clause"
+url: "https://github.com/org/my-package"
+repository-code: "https://github.com/org/my-package"
+keywords:
+  - "scientific computing"
+  - "data analysis"
+  - "astronomy"
+abstract: "A one-paragraph description of the software."
+```
+
+**Citing a related publication:**
+
+```yaml
+preferred-citation:
+  type: article
+  title: "My Package: A Tool for Scientific Analysis"
+  authors:
+    - family-names: "Smith"
+      given-names: "Jane"
+  journal: "Journal of Open Source Software"
+  year: 2025
+  volume: 10
+  issue: 100
+  start: 1234
+  doi: "10.21105/joss.01234"
+```
+
+**Validation:** Use the `cffconvert` tool to validate your CITATION.cff:
+
+```bash
+pip install cffconvert
+cffconvert --validate
+```
+
+See [assets/CITATION-template.cff](assets/CITATION-template.cff) for a complete template.
+
+## Issue Templates
+
+GitHub supports YAML-based issue forms that provide structured fields for reporters. Place these in `.github/ISSUE_TEMPLATE/`.
+
+### Bug Report Template
+
+```yaml
+# .github/ISSUE_TEMPLATE/bug_report.yml
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill out the sections below
+        to help us reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal code example or steps to reproduce the bug
+      placeholder: |
+        ```
+        # Minimal code or steps that trigger the bug
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened (include error messages and tracebacks)
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Your environment details
+      placeholder: |
+        - OS: [e.g., Ubuntu 22.04, macOS 14, Windows 11]
+        - Language/runtime version: [e.g., Python 3.12, Rust 1.75, Node 20]
+        - Package version: [e.g., 1.2.3]
+        - Installation method: [e.g., pip, conda, cargo, npm, source]
+    validations:
+      required: true
+```
+
+### Feature Request Template
+
+```yaml
+# .github/ISSUE_TEMPLATE/feature_request.yml
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: A clear description of the feature you would like
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you have considered
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, references, or screenshots
+```
+
+### Template Chooser Configuration
+
+```yaml
+# .github/ISSUE_TEMPLATE/config.yml
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and Discussion
+    url: https://github.com/org/repo/discussions
+    about: Ask questions and discuss ideas here
+  - name: Security Vulnerabilities
+    url: https://github.com/org/repo/security/advisories/new
+    about: Report security vulnerabilities privately
+```
+
+## Pull Request Template
+
+Place at `.github/PULL_REQUEST_TEMPLATE.md`:
+
+```markdown
+## Description
+
+<!-- Briefly describe the changes in this PR -->
+
+## Related Issues
+
+<!-- Link to related issues: Fixes #123, Closes #456 -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD or infrastructure change
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
+- [ ] My code follows the project's code style
+- [ ] I have added tests that prove my fix/feature works
+- [ ] All new and existing tests pass
+- [ ] I have updated the documentation as needed
+- [ ] I have added an entry to the changelog (if applicable)
+- [ ] My changes do not introduce new warnings
+
+## Testing
+
+<!-- Describe the tests you ran and how to reproduce them -->
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots to help explain your changes -->
+```
+
+## Best Practices for Research Software Projects
+
+### Open Science and Transparency
+
+1. **Choose permissive licenses** to maximize adoption in the research community
+2. **Archive releases on Zenodo** to get DOIs for each version
+3. **Include CITATION.cff** so researchers can cite your software properly
+4. **Document algorithms and methods** with references to publications
+5. **Provide example data and notebooks** for reproducibility
+6. **Publish in JOSS** (Journal of Open Source Software) for peer review and visibility
+
+### Reproducibility
+
+1. **Pin dependency versions** in CI and documentation examples
+2. **Use containerization** (Docker, Singularity) for complex environments
+3. **Document data formats** and provide sample data files
+4. **Include random seed management** for stochastic methods
+5. **Version your data** alongside your code when possible
+6. **Provide environment specification files** appropriate for your language (requirements.txt, environment.yml, Cargo.lock, package-lock.json, etc.)
+
+### Community Engagement
+
+1. **Respond to issues and PRs promptly** (even if just to acknowledge receipt)
+2. **Label issues clearly** for new contributor discoverability (`good first issue`, `help wanted`)
+3. **Write a detailed CONTRIBUTING.md** with setup instructions
+4. **Use GitHub Discussions** for questions and ideas (keep issues for actionable items)
+5. **Recognize all contributors** (code, docs, design, testing, mentoring)
+6. **Hold regular community meetings** or office hours for larger projects
+7. **Create a GOVERNANCE.md** once the project has multiple maintainers
+
+### Scientific Software Specific Considerations
+
+1. **Validate against known results** - include tests that compare against published values
+2. **Document physical units** - clearly state what units your functions expect and return
+3. **Handle edge cases in domain** - NaN values, empty datasets, boundary conditions
+4. **Provide domain-specific issue templates** - include fields for scientific context
+5. **Credit data sources** - acknowledge datasets, catalogs, and databases used
+6. **Follow field conventions** - use standard variable names, coordinate systems, and formats
+
+## File Templates
+
+Ready-to-use templates are available in the `assets/` directory:
+
+- **[assets/README-template.md](assets/README-template.md)** - Complete README template for research software projects
+- **[assets/CONTRIBUTING-template.md](assets/CONTRIBUTING-template.md)** - Contribution guidelines template
+- **[assets/CODE_OF_CONDUCT-template.md](assets/CODE_OF_CONDUCT-template.md)** - Contributor Covenant v2.1 adapted for scientific communities
+- **[assets/SECURITY-template.md](assets/SECURITY-template.md)** - Security policy template
+- **[assets/CITATION-template.cff](assets/CITATION-template.cff)** - CITATION.cff template for academic software
+
+## Reference Guides
+
+Detailed reference documentation for complex topics. Agents should consult the table of contents in each file and read specific sections as needed.
+
+- **[references/LICENSE_GUIDE.md](references/LICENSE_GUIDE.md)** - License selection for research software: decision flowchart, permissive vs copyleft comparison, SPDX identifiers for all languages, license compatibility matrix, CLA/DCO guidance, and funding agency requirements
+- **[references/CITATION_FORMAT.md](references/CITATION_FORMAT.md)** - Citation File Format (CFF) specification: required/recommended fields, ORCID integration, Zenodo DOI minting, JOSS requirements, preferred-citation for papers, and language-specific patterns
+- **[references/GITHUB_TEMPLATES.md](references/GITHUB_TEMPLATES.md)** - GitHub issue forms and PR templates: YAML form syntax, all 5 input types, complete bug report and feature request examples, template chooser config, and organization-level defaults
+
+## Community Health Files Checklist
+
+Use this checklist when setting up or auditing a project:
+
+- [ ] README.md exists with project description, installation, and usage
+- [ ] LICENSE file is present with appropriate open-source license
+- [ ] CONTRIBUTING.md explains how to contribute
+- [ ] CODE_OF_CONDUCT.md establishes behavior standards
+- [ ] SECURITY.md describes vulnerability reporting process
+- [ ] SUPPORT.md directs users to help resources
+- [ ] CITATION.cff provides citation metadata (for academic projects)
+- [ ] .github/FUNDING.yml configured (if accepting sponsorship)
+- [ ] Issue templates created for bug reports and feature requests
+- [ ] Pull request template includes checklist and description fields
+- [ ] CHANGELOG.md tracks notable changes per release
+- [ ] GitHub community profile shows green checkmarks
+- [ ] Organization-level defaults considered (for multi-repo orgs)
+- [ ] All contact emails and URLs are current and monitored
+- [ ] Templates have been tested by creating sample issues and PRs
+
+## Resources
+
+- **GitHub Community Health Files**: <https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions>
+- **Contributor Covenant**: <https://www.contributor-covenant.org/>
+- **Citation File Format**: <https://citation-file-format.github.io/>
+- **Keep a Changelog**: <https://keepachangelog.com/>
+- **Choose a License**: <https://choosealicense.com/>
+- **JOSS (Journal of Open Source Software)**: <https://joss.theoj.org/>
+- **Zenodo**: <https://zenodo.org/>
+- **Scientific Python Development Guide**: <https://learn.scientific-python.org/development/>
+- **GitHub Issue Forms**: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests>
+- **All Contributors**: <https://allcontributors.org/>
+- **REUSE (License Compliance)**: <https://reuse.software/>
+- **Software Sustainability Institute**: <https://www.software.ac.uk/>

--- a/plugins/project-management/skills/community-health-files/assets/CITATION-template.cff
+++ b/plugins/project-management/skills/community-health-files/assets/CITATION-template.cff
@@ -1,0 +1,102 @@
+# This CITATION.cff file was generated with the community-health-files skill.
+# Visit https://citation-file-format.github.io/ for full documentation.
+# Validate this file: pip install cffconvert && cffconvert --validate
+
+cff-version: 1.2.0
+
+# A message to users of the software to let them know how to cite it.
+message: "If you use this software, please cite it using the metadata from this file."
+
+# The type of work. Use "software" for software projects.
+type: software
+
+# The title of the software.
+title: "Project Name"
+
+# A brief description of the software.
+abstract: >-
+  A one-paragraph description of the software, what it does, and
+  what scientific problems it addresses. This should be concise but
+  informative enough for someone to understand the purpose and scope
+  of the project.
+
+# The authors of the software. List all significant contributors.
+# ORCID identifiers are strongly recommended for academic authors.
+authors:
+  - family-names: "Last Name"
+    given-names: "First Name"
+    email: "author@example.com"
+    affiliation: "University or Institution"
+    orcid: "https://orcid.org/0000-0000-0000-0000"
+  - family-names: "Last Name"
+    given-names: "First Name"
+    affiliation: "University or Institution"
+    orcid: "https://orcid.org/0000-0000-0000-0000"
+
+# The version of the software being cited.
+# Update this with each release.
+version: "0.1.0"
+
+# The date the version was released.
+date-released: "2025-01-15"
+
+# A DOI for the software. Obtain one from Zenodo by archiving a release.
+# doi: "10.5281/zenodo.XXXXXXX"
+
+# The license under which the software is distributed.
+# Use SPDX identifiers: https://spdx.org/licenses/
+license: "BSD-3-Clause"
+
+# The URL of the software's homepage or documentation site.
+url: "https://project-name.readthedocs.io"
+
+# The URL of the source code repository.
+repository-code: "https://github.com/ORG/REPO"
+
+# Keywords describing the software for discoverability.
+keywords:
+  - "scientific computing"
+  - "data analysis"
+  - "research software"
+
+# Identifiers for the software (DOIs, URLs, SWH IDs).
+# identifiers:
+#   - type: doi
+#     value: "10.5281/zenodo.XXXXXXX"
+#     description: "Zenodo archive of all versions"
+#   - type: doi
+#     value: "10.5281/zenodo.YYYYYYY"
+#     description: "Zenodo archive of version 0.1.0"
+
+# References to related works (papers, datasets, other software).
+# references:
+#   - type: article
+#     title: "Paper Title That Describes the Methods"
+#     authors:
+#       - family-names: "Last Name"
+#         given-names: "First Name"
+#     journal: "Journal Name"
+#     year: 2025
+#     volume: 1
+#     issue: 1
+#     start: 1
+#     end: 10
+#     doi: "10.1234/example.2025.001"
+
+# If there is a preferred citation (e.g., a journal article), specify it here.
+# GitHub will show this as the primary citation, with the software metadata
+# as a secondary option.
+# preferred-citation:
+#   type: article
+#   title: "Project Name: A Tool for Scientific Analysis"
+#   authors:
+#     - family-names: "Last Name"
+#       given-names: "First Name"
+#       orcid: "https://orcid.org/0000-0000-0000-0000"
+#   journal: "Journal of Open Source Software"
+#   year: 2025
+#   volume: 10
+#   issue: 100
+#   start: 1234
+#   doi: "10.21105/joss.01234"
+#   url: "https://doi.org/10.21105/joss.01234"

--- a/plugins/project-management/skills/community-health-files/assets/CODE_OF_CONDUCT-template.md
+++ b/plugins/project-management/skills/community-health-files/assets/CODE_OF_CONDUCT-template.md
@@ -1,0 +1,180 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+We recognize that scientific communities thrive when diverse perspectives are
+welcomed, respectful discourse is maintained, and all participants feel safe
+to contribute their ideas and expertise.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+* Engaging in respectful scientific discourse, including when disagreeing with
+  methodologies, results, or interpretations
+* Acknowledging the contributions and expertise of others
+* Providing constructive and specific feedback in code reviews and discussions
+* Supporting newcomers and those learning new skills
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Using someone's research data, code, or unpublished results without proper
+  attribution or permission
+* Dismissing or belittling others' contributions based on their career stage,
+  institutional affiliation, or educational background
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+This includes, but is not limited to:
+
+* GitHub repositories, issues, pull requests, and discussions
+* Project communication channels (Slack, Discord, mailing lists)
+* Project-related events, workshops, and conferences
+* Social media interactions related to the project
+* Presentations and talks about the project
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at:
+
+**[conduct@example.com]**
+
+<!-- Replace with actual contact information. Consider listing specific
+     individuals rather than a generic email for accountability. For example:
+
+     * Jane Smith (jane@example.com)
+     * John Doe (john@example.com)
+
+     Ensure that at least two people receive reports for accountability
+     and in case one of the recipients is the subject of the report. -->
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Reporting Process
+
+If you experience or witness unacceptable behavior, or have any other concerns,
+please report it as soon as possible:
+
+1. **Email**: Send a detailed report to [conduct@example.com]
+2. **Include**: What happened, when and where it happened, any witnesses, and
+   any supporting evidence (screenshots, links)
+3. **Acknowledgment**: You will receive an acknowledgment within 48 hours
+4. **Investigation**: The enforcement team will review the report and may
+   contact you for additional information
+5. **Resolution**: You will be informed of the outcome and any actions taken
+
+Reports can be made anonymously, though this may limit our ability to follow up
+or take certain actions.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/plugins/project-management/skills/community-health-files/assets/CONTRIBUTING-template.md
+++ b/plugins/project-management/skills/community-health-files/assets/CONTRIBUTING-template.md
@@ -1,0 +1,331 @@
+# Contributing to [Project Name]
+
+Thank you for your interest in contributing to [Project Name]! This document
+provides guidelines and instructions for contributing. We value all forms of
+contribution, including code, documentation, bug reports, feature requests,
+and community support.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [How to Contribute](#how-to-contribute)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Enhancements](#suggesting-enhancements)
+- [Development Setup](#development-setup)
+- [Making Changes](#making-changes)
+- [Code Style](#code-style)
+- [Testing](#testing)
+- [Documentation](#documentation)
+- [Pull Request Process](#pull-request-process)
+- [Release Process](#release-process)
+- [Getting Help](#getting-help)
+
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code. Please report unacceptable
+behavior to [conduct@example.com].
+
+## How to Contribute
+
+There are many ways to contribute to [Project Name]:
+
+- **Report bugs** by opening a [bug report issue](https://github.com/ORG/REPO/issues/new?template=bug_report.yml)
+- **Suggest features** by opening a [feature request](https://github.com/ORG/REPO/issues/new?template=feature_request.yml)
+- **Fix bugs** by submitting pull requests for open issues labeled [`bug`](https://github.com/ORG/REPO/labels/bug)
+- **Add features** by submitting pull requests for approved feature requests
+- **Improve documentation** by fixing typos, adding examples, or writing tutorials
+- **Review pull requests** by providing constructive feedback
+- **Help others** by answering questions in [GitHub Discussions](https://github.com/ORG/REPO/discussions)
+
+### Good First Issues
+
+If you are new to the project, look for issues labeled
+[`good first issue`](https://github.com/ORG/REPO/labels/good%20first%20issue).
+These are specifically curated to be approachable for newcomers.
+
+## Reporting Bugs
+
+Before reporting a bug, please:
+
+1. **Search existing issues** to see if the bug has already been reported
+2. **Update to the latest version** to check if the bug has been fixed
+3. **Create a minimal reproducible example** that demonstrates the issue
+
+When filing a bug report, include:
+
+- A clear and descriptive title
+- Steps to reproduce the behavior
+- Expected behavior vs. actual behavior
+- Error messages and full tracebacks
+- Your environment details:
+  - Operating system and version
+  - Language/runtime version
+  - Package version
+  - How you installed the package
+  - Versions of key dependencies
+
+## Suggesting Enhancements
+
+Enhancement suggestions are welcome. When suggesting a feature:
+
+- **Describe the problem** your feature would solve
+- **Describe the solution** you would like
+- **Describe alternatives** you have considered
+- **Provide context** such as links to related discussions, papers, or implementations
+
+For scientific features, please include:
+
+- References to relevant publications or algorithms
+- Example use cases from your research domain
+- Sample input/output data if applicable
+
+## Development Setup
+
+### Prerequisites
+
+- [Language/Runtime] >= [version]
+- Git
+- A GitHub account
+
+### Setting Up Your Development Environment
+
+1. **Fork the repository** on GitHub
+
+2. **Clone your fork:**
+
+   ```bash
+   git clone https://github.com/YOUR-USERNAME/REPO.git
+   cd REPO
+   ```
+
+3. **Add the upstream remote:**
+
+   ```bash
+   git remote add upstream https://github.com/ORG/REPO.git
+   ```
+
+4. **Install dependencies using your project's package manager:**
+
+   <!-- Replace with the appropriate commands for your ecosystem. Examples: -->
+
+   ```bash
+   # Python
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   pip install -e ".[dev]"
+
+   # Rust
+   # cargo build
+
+   # Node.js
+   # npm install
+
+   # Or if using pixi (multi-language):
+   # pixi install
+   ```
+
+5. **Install pre-commit hooks (if applicable):**
+
+   ```bash
+   pre-commit install
+   ```
+
+6. **Verify your setup by running the tests:**
+
+   ```bash
+   # Run the project's test suite using the appropriate test runner
+   ```
+
+## Making Changes
+
+### Branch Naming
+
+Create a descriptive branch name from the latest `main`:
+
+```bash
+git checkout main
+git pull upstream main
+git checkout -b your-branch-name
+```
+
+Use these prefixes for branch names:
+
+- `fix/` - Bug fixes (e.g., `fix/incorrect-unit-conversion`)
+- `feature/` - New features (e.g., `feature/add-spectral-analysis`)
+- `docs/` - Documentation changes (e.g., `docs/update-installation-guide`)
+- `refactor/` - Code refactoring (e.g., `refactor/simplify-io-module`)
+- `test/` - Test additions or improvements (e.g., `test/add-edge-case-tests`)
+
+### Commit Messages
+
+Write clear, descriptive commit messages:
+
+```
+Short summary of change (50 characters or less)
+
+More detailed explanation if needed. Wrap at 72 characters. Explain
+the problem this commit solves and why this approach was chosen.
+
+- Bullet points are fine
+- Use a hyphen for list items
+
+Fixes #123
+```
+
+**Guidelines:**
+
+- Use the imperative mood ("Add feature" not "Added feature")
+- First line is a concise summary (50 characters or less)
+- Separate the summary from the body with a blank line
+- Reference relevant issues and pull requests
+
+## Code Style
+
+This project follows the coding conventions established by the community for its primary language.
+
+### Formatting and Linting
+
+We use automated tools to enforce consistent code style. If the project uses [pre-commit](https://pre-commit.com/), hooks run automatically on each commit.
+
+<!-- Replace the tools below with those used by your project. Examples by ecosystem:
+     Python:  ruff (linting + formatting), mypy (type checking)
+     Rust:    cargo fmt (formatting), cargo clippy (linting)
+     Node.js: eslint (linting), prettier (formatting)
+     Go:      gofmt (formatting), golangci-lint (linting)
+-->
+
+To run code quality checks manually:
+
+```bash
+# Run all pre-commit hooks (if configured)
+pre-commit run --all-files
+
+# Or run your language-specific linter and formatter directly
+```
+
+### Code Conventions
+
+- Follow the established style guide for your language
+- Use type annotations where supported by the language
+- Write documentation comments for all public functions, classes, and modules
+- Keep functions focused and reasonably sized
+- Prefer clear, readable code over clever solutions
+
+### Documentation Comment Example
+
+<!-- Replace with a documentation comment example in your project's language and style. -->
+
+## Testing
+
+All contributions must include appropriate tests.
+
+<!-- Replace with the test framework and commands used by your project. Examples:
+     Python:  pytest
+     Rust:    cargo test
+     Node.js: npm test / jest / vitest
+     Go:      go test ./...
+-->
+
+### Running Tests
+
+```bash
+# Run all tests
+# <your test command here>
+
+# Run a specific test file
+# <your test command for a single file>
+
+# Run with coverage report
+# <your coverage command here>
+```
+
+### Writing Tests
+
+- Place tests in the project's designated test directory, mirroring the source structure
+- Follow the naming conventions of the test framework
+- Test edge cases and error conditions
+- Use parameterized tests for verifying multiple inputs
+- Use shared fixtures or helpers for common test data
+- Aim for at least 90% code coverage for new code
+
+## Documentation
+
+Good documentation is essential for scientific software. When contributing:
+
+- **Update docstrings** for any functions or classes you change
+- **Update the user guide** if you add or change features
+- **Add examples** that demonstrate real-world usage
+- **Update the changelog** (CHANGELOG.md) with a summary of your changes
+
+### Building Documentation Locally
+
+```bash
+# Install documentation dependencies (if separate from dev dependencies)
+# <your install command here>
+
+# Build the docs
+cd docs
+make html
+
+# View the docs (opens in browser)
+open _build/html/index.html  # macOS
+xdg-open _build/html/index.html  # Linux
+```
+
+## Pull Request Process
+
+1. **Ensure your branch is up to date** with the latest `main`:
+
+   ```bash
+   git fetch upstream
+   git rebase upstream/main
+   ```
+
+2. **Push your branch** to your fork:
+
+   ```bash
+   git push origin your-branch-name
+   ```
+
+3. **Open a pull request** against the `main` branch of the upstream repository
+
+4. **Fill out the PR template** completely, including:
+   - Description of the changes
+   - Related issue numbers
+   - Type of change
+   - Testing details
+   - Checklist completion
+
+5. **Wait for review.** A maintainer will review your PR and may request changes.
+   Please respond to feedback promptly and push additional commits as needed.
+
+6. **CI checks must pass.** All automated tests, linting, and other checks must
+   pass before your PR can be merged.
+
+### PR Review Guidelines
+
+- Be open to feedback and willing to make changes
+- Explain your design decisions when asked
+- Keep PRs focused on a single change when possible
+- Large changes should be discussed in an issue first
+
+## Release Process
+
+Releases are managed by the project maintainers. The general process is:
+
+1. Update the version number
+2. Update CHANGELOG.md
+3. Create a release tag
+4. CI automatically builds and publishes the release
+5. Update documentation
+
+## Getting Help
+
+If you need help with your contribution:
+
+- **GitHub Discussions**: Ask questions in the [Q&A category](https://github.com/ORG/REPO/discussions/categories/q-a)
+- **Issue comments**: Ask for clarification on specific issues
+- **Documentation**: Check the [development guide](https://project-name.readthedocs.io/en/latest/development/)
+
+Thank you for contributing to [Project Name]!

--- a/plugins/project-management/skills/community-health-files/assets/README-template.md
+++ b/plugins/project-management/skills/community-health-files/assets/README-template.md
@@ -1,0 +1,153 @@
+# Project Name
+
+<!-- Replace the title above with your project name -->
+
+[![CI](https://github.com/ORG/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/ORG/REPO/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/ORG/REPO/branch/main/graph/badge.svg)](https://codecov.io/gh/ORG/REPO)
+[![License](https://img.shields.io/github/license/ORG/REPO.svg)](https://github.com/ORG/REPO/blob/main/LICENSE)
+<!-- Add package registry badge(s) appropriate for your language:
+     PyPI:   [![PyPI version](https://img.shields.io/pypi/v/PACKAGE-NAME.svg)](https://pypi.org/project/PACKAGE-NAME/)
+     npm:    [![npm version](https://img.shields.io/npm/v/PACKAGE-NAME.svg)](https://www.npmjs.com/package/PACKAGE-NAME)
+     crates: [![crates.io](https://img.shields.io/crates/v/PACKAGE-NAME.svg)](https://crates.io/crates/PACKAGE-NAME)
+     conda:  [![conda-forge](https://img.shields.io/conda/vn/conda-forge/PACKAGE-NAME.svg)](https://anaconda.org/conda-forge/PACKAGE-NAME)
+-->
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
+
+<!-- Remove any badges that do not apply to your project -->
+
+## Overview
+
+<!-- Write a 2-3 sentence description of what your project does, what problem it solves,
+     and who it is for. Be specific about the scientific domain. -->
+
+**Project Name** is a [language] library/tool for [describe what it does]. It provides [key capabilities] for researchers and practitioners working in [scientific domain].
+
+## Features
+
+<!-- List the main features of your project. Focus on what makes it useful
+     for your target audience. -->
+
+- **Feature One** - Brief description of what this feature does
+- **Feature Two** - Brief description of what this feature does
+- **Feature Three** - Brief description of what this feature does
+- **Feature Four** - Brief description of what this feature does
+
+## Installation
+
+<!-- Replace the examples below with the installation method(s) appropriate for your project. -->
+
+### From package registry (recommended)
+
+```bash
+# Example for Python (PyPI):
+pip install package-name
+
+# Example for Rust (crates.io):
+# cargo add package-name
+
+# Example for Node.js (npm):
+# npm install package-name
+```
+
+### From source (for development)
+
+```bash
+git clone https://github.com/ORG/REPO.git
+cd REPO
+# Install in development mode using your project's package manager
+```
+
+### Requirements
+
+- [Language/Runtime] >= [version]
+- See [dependency file] for a full list of dependencies
+
+<!-- Update the requirements to match your project -->
+
+## Quick Start
+
+<!-- Provide a short, self-contained example that demonstrates the most common
+     use case. This should be copy-pasteable and run without errors. -->
+
+<!-- Replace with a short, self-contained example in your project's language.
+     This should be copy-pasteable and run without errors. -->
+
+```
+# Load or create example data
+# Perform the primary operation
+# Display the result
+```
+
+### More Examples
+
+<!-- Link to additional examples, notebooks, or a gallery -->
+
+For more examples, see the [examples directory](examples/) or the
+[tutorial notebooks](https://project-name.readthedocs.io/en/latest/tutorials/).
+
+## Documentation
+
+Full documentation is available at **[https://project-name.readthedocs.io](https://project-name.readthedocs.io)**.
+
+- [Getting Started Guide](https://project-name.readthedocs.io/en/latest/getting-started/)
+- [API Reference](https://project-name.readthedocs.io/en/latest/api/)
+- [Tutorials](https://project-name.readthedocs.io/en/latest/tutorials/)
+- [Changelog](CHANGELOG.md)
+
+## Contributing
+
+We welcome contributions from the community. Please read our
+[Contributing Guidelines](CONTRIBUTING.md) to get started.
+
+Some ways to contribute:
+
+- Report bugs and request features through [GitHub Issues](https://github.com/ORG/REPO/issues)
+- Submit pull requests for bug fixes or new features
+- Improve documentation or add tutorials
+- Share how you use the project in your research
+
+Please note that this project follows a [Code of Conduct](CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code.
+
+## Citation
+
+If you use this software in your research, please cite it using the metadata
+in our [CITATION.cff](CITATION.cff) file:
+
+```bibtex
+@software{project_name,
+  author       = {Author Name and Other Author},
+  title        = {Project Name: Brief Description},
+  year         = {2025},
+  publisher    = {Zenodo},
+  version      = {v1.0.0},
+  doi          = {10.5281/zenodo.XXXXXXX},
+  url          = {https://github.com/ORG/REPO}
+}
+```
+
+<!-- If there is an associated journal article, include it here as well -->
+
+## License
+
+This project is licensed under the BSD 3-Clause License. See the [LICENSE](LICENSE)
+file for details.
+
+## Acknowledgments
+
+<!-- Acknowledge funding sources, institutions, contributors, and related projects -->
+
+This project is supported by:
+
+- [Funding Agency / Grant Number](https://funding-url.example.com)
+- [Institution or Organization](https://institution.example.com)
+
+We thank all [contributors](https://github.com/ORG/REPO/graphs/contributors) who
+have helped improve this project.
+
+## Related Projects
+
+<!-- List related projects that users might find useful -->
+
+- [Related Project 1](https://github.com/org/related-1) - Brief description
+- [Related Project 2](https://github.com/org/related-2) - Brief description

--- a/plugins/project-management/skills/community-health-files/assets/SECURITY-template.md
+++ b/plugins/project-management/skills/community-health-files/assets/SECURITY-template.md
@@ -1,0 +1,140 @@
+# Security Policy
+
+## Supported Versions
+
+<!-- Update this table to reflect which versions of your project currently
+     receive security updates. -->
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+Only the latest minor release of each supported major version receives security
+patches. We recommend always running the latest version.
+
+## Reporting a Vulnerability
+
+We take the security of [Project Name] seriously. If you believe you have found
+a security vulnerability, please report it responsibly.
+
+### How to Report
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, use one of the following methods:
+
+1. **GitHub Private Vulnerability Reporting** (preferred):
+   Go to the [Security Advisories page](https://github.com/ORG/REPO/security/advisories/new)
+   and create a new private security advisory.
+
+2. **Email**: Send a detailed report to **[security@example.com]**
+
+   If possible, encrypt your message using our PGP key:
+   [Public key link or fingerprint]
+
+### What to Include
+
+Please include as much of the following information as possible to help us
+understand and address the issue:
+
+- **Description**: A clear description of the vulnerability
+- **Impact**: The potential impact and severity of the vulnerability
+- **Affected versions**: Which versions of the software are affected
+- **Steps to reproduce**: Detailed steps to reproduce the vulnerability
+- **Proof of concept**: Code or commands that demonstrate the issue (if applicable)
+- **Suggested fix**: Any ideas you have for how to fix the issue (if applicable)
+- **Environment**: Operating system, Python version, and relevant dependency versions
+
+### What to Expect
+
+After you submit a report:
+
+| Step | Timeline | Action |
+|------|----------|--------|
+| 1 | Within 48 hours | We will acknowledge receipt of your report |
+| 2 | Within 7 days | We will confirm the vulnerability and assess its impact |
+| 3 | Within 30 days | We will develop and test a fix |
+| 4 | Within 90 days | We will release the fix and publish a security advisory |
+
+These timelines are targets. Complex issues may require more time. We will keep
+you informed of our progress throughout the process.
+
+## Scope
+
+### In Scope
+
+The following are considered security concerns for this project:
+
+- **Code execution vulnerabilities**: Arbitrary code execution, injection attacks
+- **Data integrity issues**: Incorrect computation results due to exploitable flaws
+- **Dependency vulnerabilities**: Known vulnerabilities in direct dependencies
+- **Information disclosure**: Unintended exposure of sensitive data
+- **Authentication/authorization**: Issues in any access control mechanisms
+- **Denial of service**: Resource exhaustion or crash-inducing inputs
+
+### Scientific Software Specific Concerns
+
+For scientific software, we also consider the following as security-relevant:
+
+- **Data corruption**: Bugs that silently produce incorrect scientific results
+- **Supply chain attacks**: Compromised dependencies that affect data integrity
+- **Deserialization vulnerabilities**: Issues with loading data files (pickle, HDF5, etc.)
+- **Path traversal**: Issues with file path handling in data I/O operations
+
+### Out of Scope
+
+The following are generally not considered security vulnerabilities:
+
+- Bugs that cause crashes but do not expose data or allow code execution
+- Performance issues (unless they enable denial-of-service attacks)
+- Issues requiring physical access to the machine
+- Issues in unsupported versions
+- Issues in third-party dependencies (report these to the dependency maintainers)
+- Social engineering attacks
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process:
+
+1. **Reporter submits vulnerability** through a private channel
+2. **We confirm and assess** the vulnerability
+3. **We develop a fix** and prepare a release
+4. **We notify the reporter** of the planned fix and disclosure date
+5. **We release the fix** and publish a security advisory
+6. **We credit the reporter** in the advisory (with their permission)
+
+We ask reporters to:
+
+- Give us reasonable time to address the issue before public disclosure
+- Avoid exploiting the vulnerability beyond what is necessary to demonstrate it
+- Not access or modify other users' data
+- Act in good faith to avoid privacy violations, destruction of data, and
+  disruption of services
+
+## Security Best Practices for Users
+
+To keep your installation secure:
+
+- **Keep your software up to date**: Install the latest version promptly
+- **Pin dependencies**: Use lock files or pinned requirements for production
+- **Verify downloads**: Check package integrity when installing from PyPI
+- **Review changelogs**: Read the changelog for each release, especially security fixes
+- **Report issues**: If you notice anything suspicious, report it following the
+  process above
+
+## Recognition
+
+We appreciate the efforts of security researchers and community members who
+help keep [Project Name] secure. With the reporter's permission, we will
+acknowledge their contribution in:
+
+- The security advisory
+- The changelog entry for the fix
+- The project's CONTRIBUTORS file (if applicable)
+
+## Contact
+
+For security-related questions that are not vulnerability reports, please
+contact [security@example.com] or open a
+[GitHub Discussion](https://github.com/ORG/REPO/discussions).

--- a/plugins/project-management/skills/community-health-files/references/CITATION_FORMAT.md
+++ b/plugins/project-management/skills/community-health-files/references/CITATION_FORMAT.md
@@ -1,0 +1,520 @@
+# Citation File Format (CFF) Reference
+
+Complete reference for creating, validating, and maintaining CITATION.cff
+files for research software projects.
+
+**Backlinks:** Used by the `community-health-files` skill, the
+`project-onboarding-specialist` agent, and the `documentation-validator`
+agent when creating or validating citation metadata.
+
+## Table of Contents
+
+| Line | Section | Description |
+|------|---------|-------------|
+| 27   | Quick Reference | Minimal valid CITATION.cff with all required fields |
+| 53   | Required Fields | Fields every CITATION.cff must have |
+| 90   | Recommended Fields | Fields that improve discoverability and accuracy |
+| 145  | Author Metadata | Names, ORCID, affiliations, and author ordering |
+| 205  | Version and Release | Version syncing, DOI, release dates |
+| 245  | Preferred Citation | Citing a paper instead of (or alongside) the software |
+| 295  | Identifiers | DOI, SWHID, URL — linking to persistent archives |
+| 335  | Validation | Tools and CI integration for CFF validation |
+| 370  | Integration with Zenodo | Auto-archiving and DOI minting via Zenodo |
+| 410  | Integration with JOSS | Journal of Open Source Software requirements |
+| 440  | Language-Specific Patterns | How CFF interacts with pyproject.toml, Cargo.toml, etc. |
+| 475  | Common Mistakes | Frequent CFF errors and how to fix them |
+| 505  | External Resources | CFF specification, tools, and guides |
+
+---
+
+## Quick Reference
+
+Minimal valid CITATION.cff:
+
+```yaml
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "My Research Tool"
+version: "1.0.0"
+date-released: "2025-01-15"
+authors:
+  - given-names: Jane
+    family-names: Doe
+    orcid: "https://orcid.org/0000-0001-2345-6789"
+    affiliation: "University of Example"
+license: BSD-3-Clause
+repository-code: "https://github.com/org/my-research-tool"
+```
+
+This is the minimum. The sections below explain each field and the
+additional fields that improve citation quality.
+
+## Required Fields
+
+These fields are required by the CFF specification:
+
+### cff-version
+
+```yaml
+cff-version: 1.2.0
+```
+
+Always use `1.2.0` — this is the current CFF specification version. Do
+not change this unless a new CFF specification is released.
+
+### message
+
+```yaml
+message: "If you use this software, please cite it as below."
+```
+
+A human-readable message explaining how to cite the software. The example
+above is the conventional phrasing. You may customize it:
+
+```yaml
+message: "Please cite both the software and the associated paper (see preferred-citation)."
+```
+
+### title
+
+```yaml
+title: "My Research Tool"
+```
+
+The name of the software. Use the canonical name (not the package name
+or repository name, unless they are the same).
+
+### authors
+
+```yaml
+authors:
+  - given-names: Jane
+    family-names: Doe
+```
+
+At least one author is required. See line 145 for complete author metadata
+guidance including ORCID, affiliations, and ordering.
+
+## Recommended Fields
+
+These fields are not required but significantly improve citation quality:
+
+### type
+
+```yaml
+type: software
+```
+
+Valid values: `software` (default) or `dataset`. Use `software` for code
+projects.
+
+### version
+
+```yaml
+version: "1.2.0"
+```
+
+The current version of the software. Should match the version in your
+project configuration file. See line 205 for version syncing strategies.
+
+### date-released
+
+```yaml
+date-released: "2025-01-15"
+```
+
+ISO 8601 date (YYYY-MM-DD) of the current release. Update this with each
+release.
+
+### license
+
+```yaml
+license: BSD-3-Clause
+```
+
+SPDX license identifier. Must match the LICENSE file in the repository.
+See `references/LICENSE_GUIDE.md` for SPDX identifiers.
+
+### repository-code
+
+```yaml
+repository-code: "https://github.com/org/project"
+```
+
+URL of the source code repository.
+
+### url
+
+```yaml
+url: "https://project.readthedocs.io"
+```
+
+URL of the project website or documentation (if different from the repository).
+
+### doi
+
+```yaml
+doi: "10.5281/zenodo.1234567"
+```
+
+The DOI for the software. See line 295 for details on DOI types and when
+to use concept vs. version DOIs.
+
+### abstract
+
+```yaml
+abstract: >-
+  A brief description of the software and its purpose.
+  Use YAML block scalar syntax for multi-line abstracts.
+```
+
+### keywords
+
+```yaml
+keywords:
+  - climate modeling
+  - data analysis
+  - NetCDF
+```
+
+Keywords improve discoverability in citation databases.
+
+## Author Metadata
+
+### Complete Author Entry
+
+```yaml
+authors:
+  - given-names: Jane
+    family-names: Doe
+    email: "jane.doe@example.edu"
+    orcid: "https://orcid.org/0000-0001-2345-6789"
+    affiliation: "Department of Physics, University of Example"
+```
+
+### ORCID
+
+Always include ORCID identifiers when available. The ORCID must be a full
+URL:
+
+```yaml
+# Correct:
+orcid: "https://orcid.org/0000-0001-2345-6789"
+
+# Wrong:
+orcid: "0000-0001-2345-6789"
+```
+
+**Why ORCID matters:** ORCID disambiguates authors with similar names and
+links citations across databases. It is increasingly required by journals
+and funding agencies.
+
+### Name Particles and Suffixes
+
+```yaml
+authors:
+  - given-names: Ludwig
+    name-particle: van
+    family-names: Beethoven
+
+  - given-names: Martin Luther
+    family-names: King
+    name-suffix: Jr.
+```
+
+### Entity Authors (Organizations)
+
+```yaml
+authors:
+  - name: "The Astropy Collaboration"
+    website: "https://www.astropy.org"
+```
+
+Use entity authors for large collaborations where individual authorship
+is impractical.
+
+### Author Ordering
+
+CFF does not prescribe author ordering. Follow your field's conventions:
+- **Physics/Astronomy:** Alphabetical or by contribution
+- **Biology/Medicine:** First author = primary contributor, last = PI
+- **Computer Science:** First author = primary contributor
+
+Document your ordering convention in CONTRIBUTING.md so new contributors
+understand how authorship works.
+
+### Handling Many Authors
+
+For projects with many contributors, decide on a threshold. Common approaches:
+1. List all contributors who made significant code contributions
+2. List core maintainers + "The [Project] Contributors"
+3. Use an entity author for the collaboration
+
+## Version and Release
+
+### Syncing Version with Project Config
+
+The `version` in CITATION.cff should match your canonical version source.
+Strategies for keeping them in sync:
+
+**Manual update:** Update CITATION.cff version and date-released as part of
+your release checklist. Simple but error-prone.
+
+**Automated with CI:** Add a CI check that verifies the CITATION.cff version
+matches the canonical source:
+
+```bash
+# Python example: compare pyproject.toml and CITATION.cff versions
+PYPROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+CFF_VERSION=$(grep '^version:' CITATION.cff | awk '{print $2}' | tr -d '"')
+[ "$PYPROJECT_VERSION" = "$CFF_VERSION" ] || echo "Version mismatch!"
+```
+
+**Release tooling integration:** Tools like `python-semantic-release`,
+`cargo-release`, and `release-please` can be configured to update
+CITATION.cff automatically.
+
+### date-released
+
+Update on every release. Format is ISO 8601:
+
+```yaml
+date-released: "2025-06-15"
+```
+
+## Preferred Citation
+
+Use `preferred-citation` when you want users to cite a paper instead of
+(or in addition to) the software itself.
+
+### Citing a Journal Article
+
+```yaml
+message: "If you use this software, please cite the paper below."
+preferred-citation:
+  type: article
+  title: "My Research Tool: A Framework for Climate Data Analysis"
+  authors:
+    - given-names: Jane
+      family-names: Doe
+      orcid: "https://orcid.org/0000-0001-2345-6789"
+    - given-names: John
+      family-names: Smith
+  journal: "Journal of Open Source Software"
+  year: 2025
+  volume: 10
+  issue: 95
+  start: 1234
+  doi: "10.21105/joss.01234"
+```
+
+### Citing Both Software and Paper
+
+```yaml
+message: "If you use this software, please cite both the software and the paper."
+preferred-citation:
+  type: article
+  title: "The Paper Title"
+  # ... paper fields
+# The top-level fields describe the software itself
+# Users should cite both
+```
+
+### Conference Proceedings
+
+```yaml
+preferred-citation:
+  type: conference-paper
+  title: "My Tool: Efficient Analysis of Large Datasets"
+  authors:
+    - given-names: Jane
+      family-names: Doe
+  collection-title: "Proceedings of SciPy 2025"
+  year: 2025
+  doi: "10.25080/example"
+```
+
+## Identifiers
+
+### DOI (Digital Object Identifier)
+
+```yaml
+doi: "10.5281/zenodo.1234567"
+```
+
+Two types of DOIs for software:
+- **Concept DOI:** Points to all versions (e.g., `10.5281/zenodo.1234567`).
+  Always resolves to the latest version.
+- **Version DOI:** Points to a specific version (e.g., `10.5281/zenodo.1234568`).
+
+**Recommendation:** Use the **concept DOI** in the top-level `doi` field so
+the citation always resolves. Include the version-specific DOI in the
+`identifiers` section:
+
+```yaml
+doi: "10.5281/zenodo.1234567"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.1234568"
+    description: "DOI for version 1.2.0"
+```
+
+### Software Heritage ID (SWHID)
+
+```yaml
+identifiers:
+  - type: swh
+    value: "swh:1:dir:abc123..."
+    description: "Software Heritage archive"
+```
+
+Software Heritage provides permanent archival of source code.
+
+## Validation
+
+### Command-Line Validation
+
+```bash
+# Install the CFF validation tool
+pip install cffconvert
+
+# Validate CITATION.cff
+cffconvert --validate
+
+# Convert to BibTeX
+cffconvert -f bibtex
+
+# Convert to APA
+cffconvert -f apalike
+```
+
+### CI Validation with GitHub Actions
+
+```yaml
+name: CITATION.cff
+on:
+  push:
+    paths: ['CITATION.cff']
+  pull_request:
+    paths: ['CITATION.cff']
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"
+```
+
+### Online Validation
+
+Upload your CITATION.cff to https://citation-file-format.github.io/ for
+browser-based validation and format conversion.
+
+## Integration with Zenodo
+
+Zenodo automatically reads CITATION.cff when creating a release archive.
+
+**Setup:**
+1. Link your GitHub repository to Zenodo at https://zenodo.org/account/settings/github/
+2. Create a CITATION.cff with complete metadata
+3. Create a GitHub release — Zenodo automatically archives it and mints a DOI
+4. Update CITATION.cff with the minted DOI
+
+**Zenodo-specific fields:** Zenodo reads `title`, `version`, `date-released`,
+`authors`, `license`, `keywords`, and `abstract` directly from CITATION.cff.
+
+**`.zenodo.json` vs `CITATION.cff`:** If both exist, Zenodo prefers
+`.zenodo.json`. For most projects, CITATION.cff alone is sufficient. Use
+`.zenodo.json` only if you need Zenodo-specific metadata that CFF cannot
+express.
+
+## Integration with JOSS
+
+The [Journal of Open Source Software](https://joss.theoj.org/) requires
+a CITATION.cff file for submissions.
+
+**JOSS requirements:**
+- `cff-version: 1.2.0`
+- At least one author with ORCID
+- `repository-code` must point to a public repository
+- `license` must be an OSI-approved license
+- `version` should correspond to the reviewed version
+
+**After JOSS acceptance:** Update CITATION.cff to include the JOSS paper
+as `preferred-citation`:
+
+```yaml
+preferred-citation:
+  type: article
+  journal: "Journal of Open Source Software"
+  doi: "10.21105/joss.XXXXX"
+  # ... other fields
+```
+
+## Language-Specific Patterns
+
+### Python
+
+CITATION.cff version should match `pyproject.toml` version. Some tools
+(like `setuptools-scm`) can help keep them in sync.
+
+### Rust
+
+No standard integration. Include CITATION.cff in the repository root.
+`Cargo.toml` version should match.
+
+### R
+
+R has its own citation mechanism via `CITATION` file (not CITATION.cff).
+For maximum compatibility, include both:
+- `CITATION.cff` for GitHub integration and Zenodo
+- `inst/CITATION` for R's `citation()` function
+
+### Julia
+
+Julia uses `CITATION.bib` by convention. For maximum compatibility, include
+both CITATION.cff and CITATION.bib.
+
+### Node.js / Go / C++
+
+No language-specific citation mechanisms. CITATION.cff in the repository
+root is the standard.
+
+## Common Mistakes
+
+1. **ORCID without full URL.** Use `https://orcid.org/0000-...`, not just
+   the numeric identifier.
+
+2. **Version mismatch.** CITATION.cff version doesn't match the project
+   configuration file. Add a CI check (see line 205).
+
+3. **Missing date-released.** Often forgotten when manually updating.
+   Use ISO 8601 format: `YYYY-MM-DD`.
+
+4. **Wrong DOI type.** Using a version-specific DOI as the top-level `doi`
+   means the citation becomes outdated. Use the concept DOI.
+
+5. **Invalid YAML.** Unquoted special characters, wrong indentation, or
+   missing colons. Always validate with `cffconvert --validate`.
+
+6. **Not updating after release.** CITATION.cff should be updated with
+   each release (version, date-released, potentially DOI).
+
+7. **Missing preferred-citation after paper publication.** If your software
+   has an associated paper, add it as `preferred-citation`.
+
+## External Resources
+
+- [CFF Specification](https://citation-file-format.github.io/cff-initializer-guide/) — Official specification and initializer tool
+- [CFF Schema](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md) — Complete schema documentation
+- [cffconvert](https://github.com/citation-file-format/cffconvert) — CLI validation and format conversion tool
+- [CFF GitHub Action](https://github.com/citation-file-format/cffconvert-github-action) — CI validation
+- [Zenodo](https://zenodo.org/) — Research data archival and DOI minting
+- [JOSS](https://joss.theoj.org/) — Journal of Open Source Software
+- [ORCID](https://orcid.org/) — Researcher identifier registry
+- [Software Heritage](https://www.softwareheritage.org/) — Permanent source code archive
+- [FORCE11 Software Citation Principles](https://doi.org/10.7717/peerj-cs.86) — Foundational principles for software citation

--- a/plugins/project-management/skills/community-health-files/references/GITHUB_TEMPLATES.md
+++ b/plugins/project-management/skills/community-health-files/references/GITHUB_TEMPLATES.md
@@ -1,0 +1,558 @@
+# GitHub Issue and PR Templates Reference
+
+Complete reference for creating, customizing, and managing GitHub issue
+forms, PR templates, and organization-level community health defaults.
+
+**Backlinks:** Used by the `community-health-files` skill and the
+`project-onboarding-specialist` agent when scaffolding templates. Also
+referenced by the `documentation-validator` agent for completeness checks.
+
+## Table of Contents
+
+| Line | Section | Description |
+|------|---------|-------------|
+| 27   | Quick Reference | File locations and minimal examples |
+| 60   | Issue Form Syntax | YAML form schema: types, fields, validation |
+| 145  | Input Types | Detailed reference for all 5 input types |
+| 245  | Bug Report Template | Complete research software bug report form |
+| 310  | Feature Request Template | Complete feature request form |
+| 360  | PR Template | Pull request template with checklist |
+| 400  | Template Chooser | config.yml for directing users to the right template |
+| 430  | Organization-Level Defaults | .github repository for org-wide templates |
+| 465  | Template Design Principles | Best practices for research software templates |
+| 500  | Troubleshooting | Common issues and fixes |
+| 525  | External Resources | GitHub docs and community examples |
+
+---
+
+## Quick Reference
+
+### File Locations
+
+```
+.github/
+├── ISSUE_TEMPLATE/
+│   ├── bug_report.yml        # Bug report issue form
+│   ├── feature_request.yml   # Feature request issue form
+│   └── config.yml            # Template chooser configuration
+├── PULL_REQUEST_TEMPLATE.md  # Default PR template
+└── PULL_REQUEST_TEMPLATE/    # (Alternative) multiple PR templates
+    ├── default.md
+    └── release.md
+```
+
+### Minimal Issue Form
+
+```yaml
+name: Bug Report
+description: Report a bug
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+    validations:
+      required: true
+```
+
+### Minimal PR Template
+
+```markdown
+## Description
+<!-- Describe your changes -->
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] Documentation updated
+```
+
+## Issue Form Syntax
+
+GitHub issue forms use YAML to define structured forms. Each form has a
+top-level configuration and a `body` array of input elements.
+
+### Top-Level Fields
+
+```yaml
+name: "Bug Report"              # Required. Shown in template chooser.
+description: "Report a bug"     # Required. Shown in template chooser.
+title: "[Bug]: "                # Optional. Pre-filled issue title.
+labels: ["bug", "triage"]       # Optional. Auto-applied labels.
+projects: ["org/1"]             # Optional. Auto-add to project board.
+assignees:                      # Optional. Auto-assign to users.
+  - username1
+body:                           # Required. Array of form elements.
+  - type: ...
+```
+
+### Body Element Structure
+
+Every element in `body` has:
+
+```yaml
+- type: markdown | input | textarea | dropdown | checkboxes
+  id: unique_identifier         # Required for input types (not markdown)
+  attributes:                   # Type-specific configuration
+    label: "Field Label"        # Required for input types
+    description: "Help text"    # Optional
+    placeholder: "Example..."   # Optional
+    value: "Default value"      # Optional
+  validations:
+    required: true | false      # Optional, default false
+```
+
+**Rules:**
+- `id` must be unique within the form
+- `id` becomes the field key in the submitted issue body
+- `markdown` type does NOT have `id` or `validations`
+- Labels appear as the field heading
+- Descriptions appear as smaller help text below the label
+
+### Labels and Projects
+
+Labels in templates are auto-applied when the issue is created:
+
+```yaml
+labels: ["bug", "needs-triage"]
+```
+
+Labels must already exist in the repository. If a label doesn't exist,
+the issue will still be created but without that label.
+
+**Tip:** Create a standard label taxonomy. See the GitHub plugin's
+issue-triage skill for a recommended label set.
+
+## Input Types
+
+### markdown
+
+Displays static text. Used for instructions, section headers, and context.
+Does NOT create a form field.
+
+```yaml
+- type: markdown
+  attributes:
+    value: |
+      ## Environment Information
+
+      Please provide details about your setup so we can reproduce the issue.
+```
+
+**Use cases:** Section headers, instructions, links to docs, warnings.
+
+### input
+
+Single-line text input.
+
+```yaml
+- type: input
+  id: version
+  attributes:
+    label: "Version"
+    description: "Which version are you using?"
+    placeholder: "e.g., 1.2.3"
+  validations:
+    required: true
+```
+
+**Use cases:** Version numbers, OS names, short identifiers.
+
+### textarea
+
+Multi-line text area. Supports markdown rendering in the submitted issue.
+
+```yaml
+- type: textarea
+  id: steps
+  attributes:
+    label: "Steps to Reproduce"
+    description: "Provide a minimal reproducible example"
+    placeholder: |
+      1. Install the package
+      2. Run the following code:
+      ```
+      import mypackage
+      mypackage.do_thing()
+      ```
+      3. Observe the error
+    render: bash  # Optional: syntax highlighting for the field
+  validations:
+    required: true
+```
+
+**The `render` attribute:** When set, the field renders as a code block
+with the specified language highlighting. The user's input is wrapped in
+triple backticks automatically.
+
+Valid render languages: Any GitHub-supported language identifier (python,
+bash, json, yaml, r, rust, go, julia, cpp, etc.).
+
+**Use cases:** Bug descriptions, code examples, error logs, detailed text.
+
+### dropdown
+
+Single or multi-select dropdown menu.
+
+```yaml
+- type: dropdown
+  id: severity
+  attributes:
+    label: "Severity"
+    description: "How severe is this issue?"
+    options:
+      - "Critical - crashes or data loss"
+      - "Major - feature broken, no workaround"
+      - "Minor - feature broken, workaround exists"
+      - "Cosmetic - visual or documentation issue"
+    multiple: false  # Set to true for multi-select
+  validations:
+    required: true
+```
+
+**Use cases:** Severity levels, categories, environment selection, component
+selection.
+
+### checkboxes
+
+One or more checkboxes. Useful for acknowledgments and multi-select options.
+
+```yaml
+- type: checkboxes
+  id: terms
+  attributes:
+    label: "Acknowledgments"
+    options:
+      - label: "I have searched existing issues for duplicates"
+        required: true
+      - label: "I am using the latest version"
+      - label: "I have read the contributing guidelines"
+```
+
+**Use cases:** Duplicate check acknowledgment, terms acceptance, feature
+selection, environment checklist.
+
+**Note:** Individual checkbox items can be independently required, unlike
+other input types where `required` applies to the whole field.
+
+## Bug Report Template
+
+A comprehensive bug report template for research software:
+
+```yaml
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill out the sections below
+        so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: >-
+        Provide a minimal, complete, and verifiable example.
+        Include code, data (or synthetic data), and the exact commands used.
+      placeholder: |
+        1. Install: ...
+        2. Run:
+        ```
+        # minimal code that triggers the bug
+        ```
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include full error messages or tracebacks.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version of this software are you using?
+      placeholder: "e.g., 1.2.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - HPC / cluster
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Details
+      description: >-
+        Language/runtime version, package manager, relevant dependency versions,
+        or any other environment details.
+      placeholder: |
+        Language version: ...
+        Package manager: ...
+        Key dependency versions: ...
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Verification
+      options:
+        - label: I have searched existing issues for duplicates
+          required: true
+        - label: I can reproduce this on the latest released version
+```
+
+## Feature Request Template
+
+```yaml
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: >-
+        What problem does this feature solve? Describe the use case.
+        "I'm frustrated when..." or "It would be useful to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: >-
+        Describe the solution you'd like. Include API sketches, pseudocode,
+        or example usage if applicable.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: >-
+        What alternatives have you considered? Include workarounds you
+        currently use.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - "New feature"
+        - "Enhancement to existing feature"
+        - "Performance improvement"
+        - "Documentation improvement"
+        - "Developer experience"
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: "I would be willing to submit a PR for this feature"
+```
+
+## PR Template
+
+Place at `.github/PULL_REQUEST_TEMPLATE.md`:
+
+```markdown
+## Description
+
+<!-- Describe the changes and their purpose. Link to related issues. -->
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD or infrastructure change
+
+## Checklist
+
+- [ ] My code follows the project's coding conventions
+- [ ] I have added tests that prove my fix/feature works
+- [ ] New and existing tests pass locally
+- [ ] I have updated documentation as needed
+- [ ] I have added an entry to CHANGELOG.md (if applicable)
+
+## Testing
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+```
+
+## Template Chooser
+
+Create `.github/ISSUE_TEMPLATE/config.yml` to customize the template
+chooser:
+
+```yaml
+blank_issues_enabled: false  # Disable blank issue creation
+contact_links:
+  - name: Documentation
+    url: https://project.readthedocs.io
+    about: Check the documentation before filing an issue
+  - name: Discussions
+    url: https://github.com/org/project/discussions
+    about: Ask questions and get help from the community
+  - name: Security Vulnerabilities
+    url: https://github.com/org/project/security/advisories/new
+    about: Report security vulnerabilities privately
+```
+
+**`blank_issues_enabled: false`** forces users to use a template. This
+improves issue quality but may frustrate users with edge cases. Consider
+leaving it `true` for smaller projects.
+
+**`contact_links`** appear alongside issue templates in the chooser. Use
+them to redirect users to documentation, discussions, or security reporting
+before they file an issue.
+
+## Organization-Level Defaults
+
+The special `.github` repository (no other name — literally `.github`) at
+the organization level provides default templates for all repositories.
+
+### How It Works
+
+1. Create a repository named `.github` in your organization
+2. Add templates in `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`
+3. Any repository without its own templates inherits from the org `.github` repo
+
+### Precedence
+
+Repository-level templates override organization-level templates completely.
+There is no merging — if a repo has any issue templates, the org-level
+templates are ignored.
+
+### What Can Be Shared
+
+| File | Org-Level Supported |
+|------|-------------------|
+| Issue templates | Yes |
+| PR template | Yes |
+| CODE_OF_CONDUCT.md | Yes |
+| CONTRIBUTING.md | Yes |
+| SECURITY.md | Yes |
+| SUPPORT.md | Yes |
+| FUNDING.yml | Yes |
+| LICENSE | No (must be per-repo) |
+| README.md | No (must be per-repo) |
+
+**Note:** For deeper guidance on GitHub organization management, see the
+GitHub plugin's github-org-management skill.
+
+## Template Design Principles
+
+### For Research Software Projects
+
+1. **Require reproducibility information.** Bug reports should request
+   minimal reproducible examples, environment details, and version numbers.
+
+2. **Don't over-require fields.** Make description and reproduction steps
+   required; make environment details and severity optional. Too many
+   required fields discourage reporting.
+
+3. **Use dropdowns for structured data.** Operating system, severity, and
+   scope are better as dropdowns than free text — easier to triage.
+
+4. **Include a duplicate check.** The "I have searched existing issues"
+   checkbox reduces duplicate filing by prompting users to search first.
+
+5. **Link to documentation.** Use the template chooser's `contact_links`
+   to direct users to docs before they file an issue.
+
+6. **Language-neutral fields.** Use "Version" not "Python version". Use
+   "Environment Details" not "pip list output". This keeps templates
+   useful for any language.
+
+7. **Separate bug reports from feature requests.** They have different
+   information needs and different triage workflows.
+
+### PR Template Design
+
+1. **Link to issues.** Include a `Closes #` field to encourage PR-issue linking.
+2. **Checklist over prose.** Checklists are faster to complete and easier to review.
+3. **Include testing expectations.** Remind contributors to add tests.
+4. **Keep it short.** A PR template over 20 lines discourages contributions.
+
+## Troubleshooting
+
+### Template Not Appearing
+
+- File must be in `.github/ISSUE_TEMPLATE/` (not `.github/templates/`)
+- YAML must be valid — test with `python -c "import yaml; yaml.safe_load(open('file.yml'))"`
+- `name` and `description` are required top-level fields
+- File extension must be `.yml` or `.yaml`
+
+### Labels Not Applied
+
+- Labels must already exist in the repository
+- Label names are case-sensitive
+- Create labels first: `gh label create "bug" --description "Bug report" --color d73a4a`
+
+### Form Fields Not Rendering
+
+- `id` must be unique across all fields in the form
+- `type` must be one of: `markdown`, `input`, `textarea`, `dropdown`, `checkboxes`
+- `render` attribute only works on `textarea` type
+- `options` is required for `dropdown` and `checkboxes` types
+
+### PR Template Not Used
+
+- File must be named exactly `PULL_REQUEST_TEMPLATE.md` (case-sensitive)
+- Must be in `.github/` directory (or repository root)
+- Only one default PR template is supported; multiple templates require
+  query parameter: `?template=release.md`
+
+## External Resources
+
+- [GitHub: Creating Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) — Official YAML syntax reference
+- [GitHub: Creating PR Templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) — PR template documentation
+- [GitHub: Template Chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) — config.yml documentation
+- [GitHub: Organization .github Repository](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) — Org-level defaults
+- [GitHub: Community Profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories) — Community health score

--- a/plugins/project-management/skills/community-health-files/references/LICENSE_GUIDE.md
+++ b/plugins/project-management/skills/community-health-files/references/LICENSE_GUIDE.md
@@ -1,0 +1,431 @@
+# License Selection Guide for Research Software
+
+Comprehensive reference for choosing, applying, and managing licenses in
+open-source research software projects across any language.
+
+**Backlinks:** Used by the `community-health-files` skill and the
+`project-onboarding-specialist` agent when scaffolding new projects or
+advising on license selection.
+
+## Table of Contents
+
+| Line | Section | Description |
+|------|---------|-------------|
+| 28   | Quick Decision Guide | Flowchart for choosing a license in 30 seconds |
+| 55   | Permissive Licenses | BSD-3-Clause, MIT, Apache-2.0 — when to use each |
+| 120  | Copyleft Licenses | GPL-3.0, LGPL-3.0 — when copyleft is appropriate |
+| 162  | SPDX Identifiers | Standard identifiers for project configuration files |
+| 195  | License Compatibility | Matrix of which licenses can be combined |
+| 232  | Applying a License | Step-by-step: LICENSE file, headers, config files |
+| 277  | Contributor Agreements | CLA vs DCO — when each is needed |
+| 318  | Research-Specific Considerations | Funding mandates, data licensing, patents |
+| 370  | Dual and Multi-Licensing | When and how to offer multiple licenses |
+| 395  | Common Mistakes | Frequent licensing errors and how to avoid them |
+| 420  | External Resources | Authoritative references and tools |
+
+---
+
+## Quick Decision Guide
+
+Use this flowchart to choose a license quickly. For nuanced situations, read
+the detailed sections below.
+
+```
+Is this funded by a grant with license requirements?
+├── YES → Use the mandated license (check grant terms)
+└── NO
+    ├── Do you want maximum adoption and reuse?
+    │   ├── YES → Is patent protection important?
+    │   │   ├── YES → Apache-2.0
+    │   │   └── NO → BSD-3-Clause (research default) or MIT
+    │   └── NO
+    │       ├── Must derivative works stay open source?
+    │       │   ├── YES → GPL-3.0
+    │       │   └── NO → Is this a library used by others?
+    │       │       ├── YES → LGPL-3.0
+    │       │       └── NO → GPL-3.0
+    └── Special cases:
+        ├── Data/documentation only → CC-BY-4.0
+        ├── Public domain dedication → CC0-1.0
+        └── Mixed code + data → Dual license (see line 370)
+```
+
+**Default recommendation for research software:** BSD-3-Clause. It is widely
+used across scientific computing ecosystems (NumPy, SciPy, pandas, scikit-learn,
+Astropy, xarray, yt, many JOSS-published packages) and maximizes reuse in
+both academic and commercial settings.
+
+## Permissive Licenses
+
+Permissive licenses allow broad reuse with minimal restrictions. The three
+most common for research software:
+
+### BSD-3-Clause (Recommended Default)
+
+```
+BSD 3-Clause License
+
+Copyright (c) [year], [copyright holder]
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+```
+
+**When to use:** Default choice for research software. The "no endorsement"
+clause (clause 3) prevents others from implying your institution endorses
+their work — important for universities and research organizations.
+
+**Ecosystem adoption:** NumPy, SciPy, scikit-learn, pandas, Astropy, xarray,
+Dask, napari, MDAnalysis, yt, sunpy.
+
+### MIT
+
+```
+MIT License
+
+Copyright (c) [year] [copyright holder]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software...
+```
+
+**When to use:** Simplest permissive license. No endorsement clause. Common
+in the JavaScript/Node.js, Ruby, and Rust ecosystems. Appropriate when you
+want maximum simplicity and don't need the endorsement protection.
+
+**Ecosystem adoption:** Ruby on Rails, Node.js ecosystem, Rust crate ecosystem,
+jQuery, React, Vue.js, .NET.
+
+### Apache-2.0
+
+**When to use:** When explicit patent protection is important. Includes a
+patent grant — contributors explicitly license their patents to users. More
+complex than BSD-3 or MIT.
+
+**Ecosystem adoption:** Apache projects, Android, TensorFlow, Kubernetes,
+many Google and Apache Foundation projects.
+
+**Key difference from BSD-3/MIT:** Contains an explicit patent grant (Section 3)
+and a patent retaliation clause (if you sue for patent infringement, your
+license is terminated). Important for software that may involve patented
+algorithms.
+
+**Compatibility note:** Apache-2.0 is compatible with GPL-3.0 but NOT with
+GPL-2.0.
+
+## Copyleft Licenses
+
+Copyleft licenses require derivative works to use the same (or compatible)
+license. Use when you want to ensure all modifications remain open source.
+
+### GPL-3.0
+
+**When to use:** When you want to ensure all derivative works and
+modifications remain open source. Appropriate for standalone applications
+that you don't intend for use as libraries.
+
+**Key provision:** Any software that links to or incorporates GPL-3.0 code
+must also be released under GPL-3.0 (or a compatible license).
+
+**Research impact:** Some commercial and government organizations cannot use
+GPL-licensed software due to policy restrictions. This may limit adoption.
+
+### LGPL-3.0
+
+**When to use:** Copyleft for libraries — allows proprietary software to
+link against your library without triggering copyleft for the entire
+application. Modifications to your library itself must remain open source.
+
+**Key provision:** Software can link to an LGPL library without adopting
+the LGPL, but modifications to the library itself must be released under LGPL.
+
+**Example use case:** You want your library to be widely usable (including
+by proprietary software), but you want improvements to the library itself
+to always be open source.
+
+## SPDX Identifiers
+
+Always use SPDX identifiers for machine-readable license specification.
+These are the standard identifiers recognized across all ecosystems.
+
+| License | SPDX Identifier | OSI Approved |
+|---------|-----------------|--------------|
+| BSD 3-Clause | `BSD-3-Clause` | Yes |
+| MIT | `MIT` | Yes |
+| Apache 2.0 | `Apache-2.0` | Yes |
+| GPL 3.0 | `GPL-3.0-only` | Yes |
+| GPL 3.0+ | `GPL-3.0-or-later` | Yes |
+| LGPL 3.0 | `LGPL-3.0-only` | Yes |
+| Creative Commons BY 4.0 | `CC-BY-4.0` | No (not for software) |
+| Public Domain | `CC0-1.0` | No |
+
+### Using SPDX in Project Configuration
+
+**Python (pyproject.toml):**
+```toml
+[project]
+license = {text = "BSD-3-Clause"}
+# or with a license file:
+license = {file = "LICENSE"}
+```
+
+**Rust (Cargo.toml):**
+```toml
+[package]
+license = "BSD-3-Clause"
+```
+
+**Node.js (package.json):**
+```json
+{ "license": "BSD-3-Clause" }
+```
+
+**R (DESCRIPTION):**
+```
+License: BSD_3_clause + file LICENSE
+```
+
+**Go (go.mod does not have a license field):**
+Include a LICENSE file in the repository root. Go tooling detects it
+automatically.
+
+**Julia (Project.toml):**
+```toml
+license = "BSD-3-Clause"
+```
+
+## License Compatibility
+
+When combining code from multiple projects, licenses must be compatible.
+This matrix shows which combinations are allowed:
+
+```
+                 BSD-3  MIT  Apache-2.0  LGPL-3.0  GPL-3.0
+BSD-3-Clause      Y     Y      Y           Y         Y
+MIT               Y     Y      Y           Y         Y
+Apache-2.0        Y     Y      Y           Y         Y
+LGPL-3.0          -     -      -           Y         Y
+GPL-3.0           -     -      -           -         Y
+
+Y = Can include code from the row license in a project under the column license
+- = Not compatible (the more restrictive license dominates)
+```
+
+**Key rules:**
+1. Permissive licenses (BSD-3, MIT, Apache-2.0) can be combined freely
+2. GPL-3.0 code can absorb any permissive-licensed code
+3. LGPL-3.0 code can absorb permissive code but not GPL
+4. You CANNOT take GPL code and put it in a BSD/MIT project
+5. Apache-2.0 is NOT compatible with GPL-2.0 (but IS with GPL-3.0)
+
+**Practical implication:** If you depend on a GPL-3.0 library and link to
+it, your project must also be GPL-3.0 compatible.
+
+## Applying a License
+
+### Step 1: Create the LICENSE File
+
+Place a LICENSE (or LICENSE.txt) file in the repository root containing the
+full license text. Use the exact text from https://opensource.org/licenses/
+or https://choosealicense.com/.
+
+```bash
+# Example: generate BSD-3-Clause license
+# Replace [year] and [fullname] with actual values
+curl -sL "https://choosealicense.com/licenses/bsd-3-clause/" | \
+  # Or simply copy the template from this skill's assets
+```
+
+### Step 2: Add License to Project Configuration
+
+Use the SPDX identifier in your project's configuration file (see line 162
+for language-specific examples).
+
+### Step 3: Add License Headers (Optional)
+
+Some organizations require license headers in every source file. This is
+common for Apache-2.0 and GPL projects but uncommon for BSD/MIT.
+
+**Apache-2.0 header example:**
+```
+// Copyright [year] [owner]
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+```
+
+**When to add headers:**
+- Required by your organization's policy
+- Using Apache-2.0 (recommended by the Apache Foundation)
+- Multi-file projects where the LICENSE file might not be distributed
+  with individual files
+
+**When NOT to add headers:**
+- BSD-3 or MIT projects (the LICENSE file is sufficient)
+- Projects where headers add noise without value
+- Small projects where the LICENSE file always accompanies the code
+
+### Step 4: Verify License in CITATION.cff
+
+Ensure the `license` field in CITATION.cff matches the LICENSE file:
+
+```yaml
+license: BSD-3-Clause
+```
+
+See `references/CITATION_FORMAT.md` for complete CITATION.cff guidance.
+
+## Contributor Agreements
+
+Contributor agreements clarify the intellectual property status of
+contributions. There are two main approaches:
+
+### Developer Certificate of Origin (DCO)
+
+A lightweight attestation where contributors certify they have the right
+to submit their contribution. Implemented via `Signed-off-by` lines in
+git commits.
+
+```bash
+git commit -s -m "Add feature X"
+# Produces: Signed-off-by: Name <email>
+```
+
+**Enforcement:** Use the [DCO GitHub App](https://github.com/apps/dco) to
+automatically check that all commits are signed off.
+
+**When to use:** Most research software projects. The DCO is lightweight,
+doesn't require legal review, and is well-understood in open source.
+
+### Contributor License Agreement (CLA)
+
+A formal legal document where contributors grant specific rights (typically
+copyright license and patent license) to the project maintainers.
+
+**When to use:**
+- Your organization's legal team requires it
+- You need the ability to relicense in the future
+- Commercial dual-licensing is planned
+
+**When NOT to use:**
+- Most research software projects (DCO is sufficient)
+- Small community projects (CLAs discourage contributions)
+
+**Tools:** [CLA Assistant](https://cla-assistant.io/) automates CLA signing
+via GitHub pull requests.
+
+## Research-Specific Considerations
+
+### Funding Agency Requirements
+
+Some funding agencies mandate specific licenses:
+
+| Agency | Typical Requirement |
+|--------|-------------------|
+| NSF | Often requires open access; no specific license mandate but expects compliance with data sharing policies |
+| NIH | Requires open access for publications; software increasingly expected to be open source |
+| DOE | Often requires permissive licensing for government-funded code |
+| EU Horizon Europe | Recommends open access; EUPL is an option but permissive licenses are also accepted |
+| Wellcome Trust | Requires open access |
+
+**Always check your specific grant terms.** The information above is general
+guidance and may not reflect current policy.
+
+### Data vs. Code Licensing
+
+Code and data have different licensing needs:
+
+| Content Type | Recommended License |
+|-------------|-------------------|
+| Source code | BSD-3-Clause, MIT, Apache-2.0 |
+| Documentation | CC-BY-4.0 |
+| Data (sharable) | CC-BY-4.0 or CC0-1.0 |
+| Data (restricted) | Custom data use agreement |
+| Trained models | Varies — check training data licenses |
+
+**Key principle:** Software licenses (BSD, MIT, GPL) are designed for code.
+Creative Commons licenses are designed for creative works. Don't use CC
+licenses for code or software licenses for data.
+
+### Patent Considerations
+
+If your software implements patented algorithms:
+- Apache-2.0 includes an explicit patent grant
+- BSD-3 and MIT do NOT include patent grants
+- Consider whether your institution's patent policy affects license choice
+- Consult your technology transfer office if patents are involved
+
+## Dual and Multi-Licensing
+
+Dual licensing offers the software under two or more licenses. Users choose
+which license applies to their use.
+
+**Common patterns:**
+
+1. **Permissive + Copyleft:** Offer under both MIT and GPL-3.0. Users who
+   want permissive terms use MIT; users whose project is already GPL use GPL.
+
+2. **Open Source + Commercial:** Offer under GPL-3.0 (free for open source
+   use) and a commercial license (paid, for proprietary use).
+
+3. **Code + Data split:** Code under BSD-3-Clause, data under CC-BY-4.0.
+   Document this clearly in the README.
+
+**How to implement dual licensing:**
+
+```
+# In LICENSE file:
+This project is dual-licensed under BSD-3-Clause and Apache-2.0.
+You may use this software under either license, at your option.
+
+See LICENSE-BSD and LICENSE-APACHE for the full text of each license.
+```
+
+## Common Mistakes
+
+1. **No LICENSE file at all.** Without an explicit license, the code is
+   under exclusive copyright — nobody can legally use it. Always include
+   a LICENSE file.
+
+2. **LICENSE file doesn't match project config.** The SPDX identifier in
+   pyproject.toml/Cargo.toml/package.json should match the LICENSE file.
+
+3. **Using CC licenses for code.** Creative Commons licenses are not
+   designed for software. Use BSD-3, MIT, or Apache-2.0 instead.
+
+4. **Copying GPL code into a BSD project.** License compatibility only
+   flows one way — permissive into copyleft, not the other way.
+
+5. **Forgetting to update the year.** The copyright year should reflect
+   when the code was created. Many projects use a year range (2020-2025)
+   and update it annually.
+
+6. **Not checking dependency licenses.** Your project's license must be
+   compatible with all dependency licenses. A single GPL dependency makes
+   your project effectively GPL.
+
+7. **Custom or modified license text.** Never modify the text of a standard
+   license. If you need custom terms, consult a lawyer.
+
+## External Resources
+
+- [Choose a License](https://choosealicense.com/) — Interactive license chooser
+- [SPDX License List](https://spdx.org/licenses/) — Canonical license identifiers
+- [OSI Approved Licenses](https://opensource.org/licenses/) — Full list of OSI-approved licenses
+- [tl;drLegal](https://tldrlegal.com/) — Plain-English license summaries
+- [REUSE Specification](https://reuse.software/) — Best practices for license and copyright information
+- [GitHub Licensing Guide](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) — GitHub-specific licensing guidance
+- [Scientific Python Development Guide: Licensing](https://learn.scientific-python.org/development/guides/gha-pure/) — Python-specific guidance
+- [The Turing Way: Licensing](https://the-turing-way.netlify.app/reproducible-research/licensing.html) — Research software licensing guidance

--- a/plugins/project-management/skills/documentation-validation/SKILL.md
+++ b/plugins/project-management/skills/documentation-validation/SKILL.md
@@ -1,0 +1,1134 @@
+---
+name: documentation-validation
+description: Documentation quality assurance tools and strategies for research software projects. Covers prose linting (Vale), link checking (HTMLProofer), Markdown validation (markdownlint), code example testing, container-based instruction validation, and CI integration.
+metadata:
+  references:
+    - references/VALE_CONFIGURATION.md
+    - references/DOCUMENTATION_STANDARDS.md
+    - references/VALIDATION_TOOLS.md
+  assets:
+    - assets/vale-config.ini
+    - assets/validation-checklist.md
+---
+
+# Documentation Validation
+
+A comprehensive guide to treating documentation as a first-class deliverable that can be automatically tested, linted, and validated. This skill covers prose linting, link checking, code example testing, container-based instruction validation, and CI integration for documentation quality assurance. These practices are essential for research software projects where incorrect setup instructions or broken links can cost researchers hours of wasted effort.
+
+## Resources in This Skill
+
+This skill includes supporting materials for documentation validation tasks:
+
+**References** (detailed guides — consult the table of contents in each file and read specific sections as needed):
+- `references/VALE_CONFIGURATION.md` - Complete Vale setup: .vale.ini options, style packages (proselint, write-good, Google, alex), custom rules (substitution, existence, consistency), vocabulary files, editor/CI integration, and configuration recipes
+- `references/DOCUMENTATION_STANDARDS.md` - Documentation quality frameworks: Diataxis (tutorials, how-to, reference, explanation), completeness criteria at 4 maturity levels, README standards, API doc coverage, readability metrics, documentation debt, and accessibility
+- `references/VALIDATION_TOOLS.md` - All validation tools: markdownlint rules and config, HTMLProofer for link checking, doc8 for RST, language-specific doc testing (Python/Rust/R/Go/Julia), notebook validation (nbval), CI pipeline assembly, and pre-commit integration
+
+**Assets** (ready-to-use configurations and checklists):
+- `assets/validation-checklist.md` - Comprehensive documentation completeness checklist for project handoff
+- `assets/vale-config.ini` - Vale prose linting configuration template for scientific documentation
+
+## Quick Reference Card
+
+### Validation Tool Decision Tree
+
+```
+What do you need to validate?
+|
++-- Prose quality (grammar, style, jargon)?
+|   => Vale (configurable prose linter)
+|
++-- Markdown syntax and formatting?
+|   => markdownlint / markdownlint-cli2
+|
++-- reStructuredText syntax?
+|   => doc8
+|
++-- Links (internal + external)?
+|   => HTMLProofer (for generated HTML)
+|   => markdown-link-check (for raw Markdown)
+|   => sphinx -b linkcheck (for Sphinx projects)
+|
++-- Code examples actually work?
+|   => pytest --doctest-glob (for Markdown/RST)
+|   => doctest module (for docstrings)
+|   => nbval / pytest-notebook (for Jupyter notebooks)
+|
++-- Setup instructions actually work?
+|   => Docker-based instruction testing
+|   => GitHub Actions clean environment
+|
++-- Overall documentation completeness?
+|   => Handoff checklist (see assets/validation-checklist.md)
+```
+
+### Essential Commands at a Glance
+
+```bash
+# Prose linting with Vale
+vale docs/
+
+# Markdown linting
+markdownlint-cli2 "docs/**/*.md"
+
+# reStructuredText linting
+doc8 docs/
+
+# Link checking (Sphinx)
+sphinx-build -b linkcheck docs docs/_build/linkcheck
+
+# Link checking (HTML output)
+htmlproofer docs/_build/html --check-links
+
+# Test code examples in documentation
+pytest --doctest-glob="*.md" docs/
+pytest --doctest-glob="*.rst" docs/
+
+# Notebook validation
+pytest --nbval docs/notebooks/
+
+# Container-based instruction testing
+docker build -f Dockerfile.test-docs -t docs-test .
+```
+
+## When to Use This Skill
+
+Use this skill when you need to:
+
+- Ensure documentation prose is clear, consistent, and free of common writing issues
+- Validate that all links in documentation (internal and external) resolve correctly
+- Test that code examples embedded in documentation actually execute and produce expected output
+- Verify that setup and installation instructions work in a clean environment
+- Set up continuous integration pipelines that automatically check documentation quality
+- Prepare a project for handoff by verifying documentation completeness
+- Establish documentation quality standards for a team or organization
+- Audit existing documentation for staleness, broken links, or incomplete coverage
+- Lint reStructuredText or Markdown files for syntax errors and style consistency
+- Test Jupyter notebooks included in documentation to ensure they still execute
+
+## Validation Tools
+
+### Vale: Prose Linting
+
+**What it does:** Vale is a syntax-aware prose linter that enforces writing style rules. It checks for grammar issues, jargon, passive voice, weasel words, and adherence to style guides. Unlike generic spell checkers, Vale understands markup syntax (Markdown, RST, HTML) and only checks prose content.
+
+**Why it matters for scientific documentation:** Scientific writing often suffers from unnecessarily complex language, inconsistent terminology, and jargon that alienates newcomers. Vale enforces readable, inclusive documentation while allowing domain-specific vocabulary.
+
+**Installation:**
+
+```bash
+# macOS
+brew install vale
+
+# Linux (snap)
+snap install vale
+
+# Linux (manual)
+wget https://github.com/errata-ai/vale/releases/latest/download/vale_Linux_64-bit.tar.gz
+tar -xvzf vale_Linux_64-bit.tar.gz -C /usr/local/bin
+
+# Using pipx (cross-platform, runs the vale-cli wrapper)
+pipx install vale
+```
+
+**Configuration:**
+
+Create a `.vale.ini` in your repository root. See `assets/vale-config.ini` for a complete template. The minimal configuration is:
+
+```ini
+StylesPath = .vale/styles
+MinAlertLevel = warning
+
+Packages = proselint, write-good, Google
+
+[*.md]
+BasedOnStyles = Vale, proselint, write-good
+```
+
+After creating the config, sync the packages:
+
+```bash
+vale sync
+```
+
+**Running Vale:**
+
+```bash
+# Lint all documentation
+vale docs/
+
+# Lint a specific file
+vale docs/getting-started/installation.md
+
+# Output as JSON (useful for CI)
+vale --output=JSON docs/
+
+# Only show errors (not warnings or suggestions)
+vale --minAlertLevel=error docs/
+```
+
+**Scientific Writing Rules:**
+
+Vale supports custom rules for domain-specific needs. Create vocabulary files to allow scientific terms that would otherwise be flagged:
+
+```
+# .vale/styles/Vocab/Scientific/accept.txt
+NumPy
+SciPy
+DataFrame
+docstring
+boolean
+namespace
+reproducibility
+citable
+metadata
+```
+
+```
+# .vale/styles/Vocab/Scientific/reject.txt
+obviously
+trivially
+simply
+easy
+straightforward
+```
+
+Rejecting words like "obviously" and "simply" helps produce documentation that does not make assumptions about the reader's background, which is particularly important in scientific contexts where audiences vary widely in expertise.
+
+**Custom Vale Rule Example:**
+
+Create project-specific rules in `.vale/styles/Custom/`:
+
+```yaml
+# .vale/styles/Custom/ScientificAbbreviations.yml
+extends: existence
+message: "Expand '%s' on first use. Scientific abbreviations should be defined."
+level: warning
+tokens:
+  - '\b[A-Z]{2,}\b'
+exceptions:
+  - API
+  - CI
+  - CD
+  - URL
+  - HTML
+  - CSS
+  - JSON
+  - YAML
+  - RST
+  - PDF
+```
+
+### HTMLProofer: Link Checking for Generated Documentation
+
+**What it does:** HTMLProofer validates generated HTML documentation by checking that all links resolve, images have alt attributes, and HTML is well-formed. It is the standard tool for validating the output of Sphinx, MkDocs, and Jupyter Book builds.
+
+**Installation:**
+
+```bash
+# Requires Ruby
+gem install html-proofer
+
+# Or via Docker
+docker run --rm -v $(pwd)/docs/_build/html:/site 18fgsa/html-proofer /site
+```
+
+**Basic Usage:**
+
+```bash
+# First, build your documentation
+sphinx-build -b html docs docs/_build/html
+
+# Then validate the output
+htmlproofer docs/_build/html \
+  --check-links \
+  --check-images \
+  --allow-missing-href \
+  --ignore-status-codes "403,429"
+```
+
+**Advanced Configuration:**
+
+```bash
+htmlproofer docs/_build/html \
+  --check-links \
+  --check-images \
+  --check-scripts \
+  --enforce-https \
+  --ignore-urls "/localhost/,/127.0.0.1/,/example.com/" \
+  --ignore-status-codes "403,429,503" \
+  --swap-urls "https://docs.myproject.org:docs/_build/html" \
+  --typhoeus-config '{"timeout":30,"connecttimeout":10}' \
+  --cache '{"timeframe":{"external":"1d"}}'
+```
+
+**Alternative: Sphinx Built-in Link Checker:**
+
+For Sphinx-based projects, use the built-in linkcheck builder:
+
+```bash
+sphinx-build -b linkcheck docs docs/_build/linkcheck
+```
+
+This generates a report at `docs/_build/linkcheck/output.txt` showing the status of every external link.
+
+**Alternative for Raw Markdown: markdown-link-check:**
+
+```bash
+# Install
+npm install -g markdown-link-check
+
+# Check a file
+markdown-link-check docs/README.md
+
+# Check all markdown files
+find docs -name "*.md" -exec markdown-link-check {} \;
+
+# Using a config file
+markdown-link-check -c .markdown-link-check.json docs/README.md
+```
+
+Configuration file `.markdown-link-check.json`:
+
+```json
+{
+  "ignorePatterns": [
+    { "pattern": "^https://localhost" },
+    { "pattern": "^https://example\\.com" }
+  ],
+  "replacementPatterns": [
+    { "pattern": "^/docs", "replacement": "https://mysite.org/docs" }
+  ],
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com"],
+      "headers": { "Accept": "text/html" }
+    }
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206]
+}
+```
+
+### markdownlint: Markdown Syntax and Style Consistency
+
+**What it does:** markdownlint enforces consistent Markdown formatting and catches common syntax errors. It validates heading structure, list formatting, line length, code block syntax, and dozens of other Markdown conventions.
+
+**Installation:**
+
+```bash
+# CLI version (recommended)
+npm install -g markdownlint-cli2
+
+# Or via Docker
+docker run --rm -v $(pwd):/workdir davidanson/markdownlint-cli2 "docs/**/*.md"
+```
+
+**Configuration:**
+
+Create `.markdownlint-cli2.yaml` in your repository root:
+
+```yaml
+config:
+  # MD013 - Line length
+  MD013:
+    line_length: 120
+    code_blocks: false
+    tables: false
+    headings: false
+
+  # MD024 - Allow duplicate headings in different sections
+  MD024:
+    siblings_only: true
+
+  # MD033 - Allow specific inline HTML
+  MD033:
+    allowed_elements:
+      - details
+      - summary
+      - br
+      - sup
+      - sub
+
+  # MD041 - First line should be a heading (disable for includes)
+  MD041: false
+
+  # MD046 - Code block style
+  MD046:
+    style: fenced
+
+  # MD048 - Code fence style
+  MD048:
+    style: backtick
+
+globs:
+  - "docs/**/*.md"
+  - "*.md"
+  - "!node_modules"
+  - "!.vale"
+
+ignores:
+  - "CHANGELOG.md"
+  - "**/generated/**"
+```
+
+**Running markdownlint:**
+
+```bash
+# Lint all documentation
+markdownlint-cli2 "docs/**/*.md"
+
+# Fix auto-fixable issues
+markdownlint-cli2 --fix "docs/**/*.md"
+
+# Lint specific file
+markdownlint-cli2 docs/getting-started/installation.md
+```
+
+### doc8: reStructuredText Linting
+
+**What it does:** doc8 is an opinionated linter for reStructuredText files. It checks line length, trailing whitespace, invalid RST syntax, and other formatting issues. It is particularly useful for projects that use Sphinx with reStructuredText.
+
+**Installation:**
+
+```bash
+pip install doc8
+```
+
+**Configuration in `pyproject.toml`:**
+
+```toml
+[tool.doc8]
+max-line-length = 120
+ignore-path = [
+    "docs/_build",
+    "docs/generated",
+]
+ignore-path-errors = [
+    "docs/changelog.rst;D001",
+]
+```
+
+**Running doc8:**
+
+```bash
+# Lint all RST files in docs/
+doc8 docs/
+
+# With custom max line length
+doc8 --max-line-length 120 docs/
+
+# Ignore specific rules
+doc8 --ignore D001 docs/
+```
+
+**Common doc8 rules:**
+
+| Rule | Description |
+|------|-------------|
+| D000 | Invalid RST syntax |
+| D001 | Line too long |
+| D002 | Trailing whitespace |
+| D003 | Tabulation used for indentation |
+| D004 | Found literal block with no indentation |
+| D005 | No newline at end of file |
+
+## Documentation-as-Code Testing Strategies
+
+### Treating Documentation Like Code
+
+Documentation-as-code means applying the same practices to documentation that you apply to source code:
+
+| Practice | Code | Documentation |
+|----------|------|---------------|
+| Version control | git | git (docs live alongside code) |
+| Code review | Pull requests | Pull requests for doc changes |
+| Automated testing | pytest, CI | Vale, linkcheck, doctest, CI |
+| Linting | ruff, mypy | Vale, markdownlint, doc8 |
+| Formatting | ruff format | Prettier, markdownlint --fix |
+| Deployment | PyPI, Docker | Read the Docs, GitHub Pages |
+| Issue tracking | GitHub Issues | GitHub Issues (label: documentation) |
+
+**Key principle:** Every documentation change goes through the same review and CI pipeline as code changes. Documentation pull requests should be tested automatically before merge.
+
+### Testing Code Examples in Documentation
+
+Code examples that do not actually work are worse than no examples at all. They erode trust and waste the reader's time. Always validate that code examples execute correctly.
+
+**Using pytest with doctest-glob:**
+
+```bash
+# Test code examples in Markdown files
+pytest --doctest-glob="*.md" docs/
+
+# Test code examples in reStructuredText files
+pytest --doctest-glob="*.rst" docs/
+
+# Combine with regular tests
+pytest tests/ --doctest-glob="*.md" docs/
+```
+
+**Writing testable examples in Markdown:**
+
+````markdown
+Here is how to compute the mean of an array:
+
+```python
+>>> import numpy as np
+>>> data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+>>> np.mean(data)
+3.0
+```
+````
+
+The `>>>` prefix makes these examples discoverable by doctest. The expected output on the next line is used for assertion.
+
+**Using doctest in Python docstrings:**
+
+```bash
+# Run doctests in all module docstrings
+pytest --doctest-modules src/
+
+# Or with the standard library
+python -m doctest -v docs/tutorial.md
+```
+
+**pytest configuration for doctest:**
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+addopts = [
+    "--doctest-glob=*.md",
+    "--doctest-glob=*.rst",
+]
+doctest_optionflags = [
+    "NORMALIZE_WHITESPACE",
+    "ELLIPSIS",
+    "NUMBER",
+]
+```
+
+The `NORMALIZE_WHITESPACE` flag prevents failures from trivial whitespace differences. `ELLIPSIS` allows `...` to match any text, and `NUMBER` handles floating-point comparison tolerance.
+
+### Notebook Testing
+
+**Note:** The following section covers Python/Jupyter notebook testing. For non-Python projects, validate documentation examples using language-appropriate test frameworks (cargo test --doc for Rust, go test for Go, testthat for R, npm test for Node.js).
+
+Jupyter notebooks in documentation must be validated to ensure they still execute correctly as dependencies and APIs evolve.
+
+**nbval: Validate notebook output:**
+
+```bash
+# Install
+pip install nbval
+
+# Validate that notebooks execute and produce the same output
+pytest --nbval docs/notebooks/
+
+# Validate that notebooks execute (ignore output differences)
+pytest --nbval-lax docs/notebooks/
+
+# Skip cells tagged with 'skip' in metadata
+pytest --nbval --nbval-current-env docs/notebooks/
+```
+
+**pytest-notebook: More control over notebook testing:**
+
+```bash
+# Install
+pip install pytest-notebook
+
+# Run notebook tests
+pytest --nb-test-files docs/notebooks/
+```
+
+**Configuration for nbval in `pyproject.toml`:**
+
+```toml
+[tool.pytest.ini_options]
+nb_test_files = "docs/notebooks/"
+nb_diff_ignore = [
+    "/metadata",
+    "/cells/*/outputs/*/execution_count",
+]
+```
+
+**Tagging cells to skip during testing:**
+
+In notebook cell metadata, add:
+
+```json
+{
+  "tags": ["skip-execution"]
+}
+```
+
+Then configure nbval to respect the tag:
+
+```bash
+pytest --nbval --nbval-cell-timeout=120 docs/notebooks/
+```
+
+## Container-Based Instruction Testing
+
+### Why Test Instructions in a Clean Environment
+
+The most common documentation failure is "works on my machine" syndrome. Setup instructions that rely on undocumented system dependencies, cached packages, or pre-existing configuration will fail for new users. Testing instructions in a clean container catches these issues.
+
+### Following Setup Instructions in Docker
+
+Create a `Dockerfile.test-docs` that simulates a new user following your README:
+
+```dockerfile
+# Dockerfile.test-docs
+# Tests that setup instructions from README actually work
+
+# Replace with your language's base image (python:3.12-slim, rust:1.75, node:20-slim, etc.)
+FROM ubuntu:22.04
+
+# Start from a minimal environment
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Copy the repository
+COPY . .
+
+# Replace with your project's install command
+# Examples:
+#   Python:  pip install -e ".[dev,docs]"
+#   Rust:    cargo build
+#   Node.js: npm install
+#   R:       Rscript -e "devtools::install('.')"
+#   Go:     go build ./...
+RUN echo "Add your install command here"
+
+# Verify the installation works
+# Examples:
+#   Python:  python -c "import my_package; print(my_package.__version__)"
+#   Rust:    cargo test --no-run
+#   Node.js: node -e "require('./index')"
+RUN echo "Add your verification command here"
+
+# Run the quickstart example from the documentation
+RUN echo "Add your quickstart test command here"
+
+# Build the documentation to verify it compiles
+RUN echo "Add your documentation build command here"
+```
+
+**Build and run the test:**
+
+```bash
+# Build the image (this runs all the instructions)
+docker build -f Dockerfile.test-docs -t docs-test .
+
+# If the build succeeds, the instructions work
+echo "Documentation instructions validated successfully"
+```
+
+### Automated README Validation Script
+
+Create a script that extracts and tests code blocks from your README:
+
+```bash
+#!/usr/bin/env bash
+# scripts/test-readme.sh
+# Extract and run code blocks from README.md in a clean environment
+
+set -euo pipefail
+
+echo "=== Testing README instructions in clean Docker container ==="
+
+docker run --rm -v "$(pwd)":/workspace -w /workspace python:3.12-slim bash -c '
+    set -euo pipefail
+
+    echo "--- Installing from README instructions ---"
+    pip install -e ".[dev]" 2>&1 | tail -5
+
+    echo "--- Running import check ---"
+    python -c "import my_package; print(f\"Version: {my_package.__version__}\")"
+
+    echo "--- Running quickstart example ---"
+    python -c "
+from my_package import analyze
+result = analyze([1, 2, 3, 4, 5])
+print(f\"Result: {result}\")
+"
+    echo "--- All README instructions passed ---"
+'
+```
+
+### Multi-Environment Testing
+
+Test instructions across multiple Python versions and operating systems:
+
+```yaml
+# .github/workflows/test-docs-instructions.yml
+name: Test Documentation Instructions
+
+on:
+  push:
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "INSTALL.md"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "INSTALL.md"
+
+jobs:
+  test-instructions:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Follow installation instructions
+        run: |
+          pip install -e ".[dev,docs]"
+
+      - name: Verify import works
+        run: |
+          python -c "import my_package; print(my_package.__version__)"
+
+      - name: Run quickstart example
+        run: |
+          python docs/getting-started/quickstart_test.py
+```
+
+## GitHub Actions Integration for Automated Doc Validation
+
+### Comprehensive Documentation CI Workflow
+
+**Note:** The following CI workflow examples use Python tooling (pip, Sphinx, pytest). Adapt these patterns for your project's language and documentation build system.
+
+```yaml
+# .github/workflows/docs-validation.yml
+name: Documentation Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "*.md"
+      - ".vale.ini"
+      - ".markdownlint-cli2.yaml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "*.md"
+      - ".vale.ini"
+      - ".markdownlint-cli2.yaml"
+
+jobs:
+  prose-lint:
+    name: Prose Linting (Vale)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          files: docs/
+          reporter: github-pr-review
+          fail_on_error: true
+
+  markdown-lint:
+    name: Markdown Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: |
+            docs/**/*.md
+            *.md
+
+  link-check:
+    name: Link Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[docs]"
+      - name: Build documentation
+        run: sphinx-build -b html docs docs/_build/html
+      - name: Check links
+        run: sphinx-build -b linkcheck docs docs/_build/linkcheck
+
+  doctest:
+    name: Documentation Code Examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev,docs]"
+      - name: Run doctests in documentation
+        run: pytest --doctest-glob="*.md" --doctest-glob="*.rst" docs/
+      - name: Run doctests in source
+        run: pytest --doctest-modules src/
+
+  notebook-validation:
+    name: Notebook Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[dev,docs]" nbval
+      - name: Validate notebooks
+        run: pytest --nbval-lax docs/notebooks/
+
+  docs-build:
+    name: Documentation Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[docs]"
+      - name: Build docs (treat warnings as errors)
+        run: sphinx-build -W --keep-going -b html docs docs/_build/html
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation
+          path: docs/_build/html/
+```
+
+### Standalone Vale GitHub Action
+
+For projects that want Vale as a pull request reviewer:
+
+```yaml
+# .github/workflows/vale.yml
+name: Vale Prose Lint
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "*.md"
+
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          files: docs/
+          vale_flags: "--minAlertLevel=warning"
+          reporter: github-pr-review
+          fail_on_error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Scheduled Link Checking
+
+External links break over time. Schedule periodic link checks:
+
+```yaml
+# .github/workflows/link-check-scheduled.yml
+name: Scheduled Link Check
+
+on:
+  schedule:
+    # Run weekly on Monday at 9:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -e ".[docs]"
+      - name: Build documentation
+        run: sphinx-build -b html docs docs/_build/html
+      - name: Check links
+        run: sphinx-build -b linkcheck docs docs/_build/linkcheck
+      - name: Report broken links
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linkcheck-report
+          path: docs/_build/linkcheck/output.txt
+```
+
+## Quality Metrics and Standards
+
+### Readability Scores
+
+Readability metrics help ensure documentation is accessible to your target audience:
+
+| Metric | Target | Interpretation |
+|--------|--------|----------------|
+| Flesch Reading Ease | 40-60 (technical), 60-70 (tutorials) | Higher = easier to read |
+| Flesch-Kincaid Grade | 10-14 (technical), 8-10 (tutorials) | Grade level required to understand |
+| Gunning Fog Index | 10-14 (technical), 8-10 (tutorials) | Years of education needed |
+
+Vale can enforce readability with the `readability` package:
+
+```ini
+# .vale.ini addition
+Packages = readability
+
+[docs/tutorials/*.md]
+BasedOnStyles = Vale, readability
+readability.FleschKincaid = warning
+```
+
+### Link Health Metrics
+
+Track link health over time:
+
+| Metric | Target | Action if Below |
+|--------|--------|-----------------|
+| Internal links resolving | 100% | Fix immediately (blocks merge) |
+| External links resolving | >95% | Investigate; ignore transient 429/503 |
+| Links with redirects | <10% | Update to final URLs |
+| Links over 3 years old | <20% | Verify content still relevant |
+
+### Documentation Completeness Metrics
+
+| Category | Weight | Minimum Standard |
+|----------|--------|-----------------|
+| README with install + quickstart | Critical | Must exist |
+| API reference for public functions | Critical | 100% coverage |
+| At least one tutorial | High | Must exist |
+| Contributing guide | High | Must exist |
+| Architecture overview | Medium | Should exist for complex projects |
+| Changelog | High | Must exist and be current |
+| License file | Critical | Must exist |
+
+### Definition of "Documentation Complete"
+
+A project's documentation is considered complete when it meets all of the following criteria:
+
+1. **Buildable**: Documentation builds without warnings (`sphinx-build -W`)
+2. **Linkable**: All internal and external links resolve
+3. **Testable**: All code examples execute successfully
+4. **Linted**: Prose passes Vale checks with no errors
+5. **Structured**: Follows Diataxis framework (tutorials, how-to, reference, explanation)
+6. **Accessible**: Meets basic accessibility standards (alt text, heading hierarchy, contrast)
+7. **Complete**: Passes the handoff checklist (see `assets/validation-checklist.md`)
+8. **Reviewable**: At least one person other than the author has reviewed the docs
+9. **Findable**: Search works and navigation is logical
+10. **Current**: No documentation references deprecated APIs or removed features
+
+## Project Handoff Documentation Completeness Checklist
+
+Use this checklist when preparing a project for handoff to new maintainers, a new team, or the broader community. A detailed, standalone version with additional context is available at `assets/validation-checklist.md`.
+
+### Summary Checklist
+
+**Essential Files:**
+- [ ] README.md with project description, installation, and quickstart
+- [ ] LICENSE file with appropriate open-source license
+- [ ] CONTRIBUTING.md with contribution guidelines
+- [ ] CHANGELOG.md with version history
+- [ ] CITATION.cff for scientific projects
+
+**User Documentation:**
+- [ ] Installation guide covering all supported methods
+- [ ] Quickstart tutorial (5-minute path to first result)
+- [ ] At least one in-depth tutorial
+- [ ] API reference for all public interfaces
+- [ ] Configuration reference
+
+**Developer Documentation:**
+- [ ] Architecture overview with diagrams
+- [ ] Development environment setup guide
+- [ ] Testing guide (how to run tests, write tests, CI behavior)
+- [ ] Release process documentation
+- [ ] Dependency management explanation
+
+**Project Health:**
+- [ ] CI/CD pipeline documented and working
+- [ ] Code quality tools configured and documented
+- [ ] All tests passing
+- [ ] Documentation builds without warnings
+- [ ] No critical security vulnerabilities
+
+**Onboarding:**
+- [ ] "Getting started as a developer" guide
+- [ ] Key contacts and communication channels
+- [ ] Glossary of project-specific terms
+- [ ] Known issues and technical debt documented
+- [ ] Decision log for major architectural choices
+
+## Best Practices
+
+### Integrate Early, Validate Often
+
+Do not wait until the end of a project to validate documentation. Set up CI-based documentation validation from the start:
+
+1. Add Vale and markdownlint to pre-commit hooks for immediate feedback
+2. Run doctests as part of your regular test suite
+3. Check links on every pull request
+4. Build documentation with warnings-as-errors in CI
+5. Schedule weekly link checks for external URL decay
+
+### Pre-commit Integration
+
+Add documentation validation to your pre-commit configuration:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/errata-ai/vale
+    rev: v3.9.0
+    hooks:
+      - id: vale
+        args: [--minAlertLevel, warning]
+        types_or: [markdown, rst]
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.0
+    hooks:
+      - id: markdownlint-cli2
+        args: ["docs/**/*.md", "*.md"]
+
+  - repo: https://github.com/PyCQA/doc8
+    rev: v1.1.2
+    hooks:
+      - id: doc8
+        args: [--max-line-length, "120"]
+```
+
+### Nox Sessions for Documentation Validation
+
+**Python Example:** The following Nox sessions demonstrate documentation validation for Python projects. Adapt the patterns to your project's task runner.
+
+```python
+# noxfile.py additions for documentation validation
+import nox
+
+@nox.session(python="3.12")
+def docs_lint(session):
+    """Lint documentation prose with Vale."""
+    session.run("vale", "docs/", external=True)
+
+@nox.session(python="3.12")
+def docs_linkcheck(session):
+    """Check documentation links."""
+    session.install(".[docs]")
+    session.run(
+        "sphinx-build", "-b", "linkcheck",
+        "docs", "docs/_build/linkcheck",
+    )
+
+@nox.session(python="3.12")
+def docs_doctest(session):
+    """Test code examples in documentation."""
+    session.install(".[dev,docs]")
+    session.run(
+        "pytest",
+        "--doctest-glob=*.md",
+        "--doctest-glob=*.rst",
+        "docs/",
+    )
+
+@nox.session(python="3.12")
+def docs_notebooks(session):
+    """Validate Jupyter notebooks in documentation."""
+    session.install(".[dev,docs]", "nbval")
+    session.run(
+        "pytest", "--nbval-lax",
+        "docs/notebooks/",
+    )
+
+@nox.session(python="3.12")
+def docs_build(session):
+    """Build documentation with warnings as errors."""
+    session.install(".[docs]")
+    session.run(
+        "sphinx-build", "-W", "--keep-going",
+        "-b", "html",
+        "docs", "docs/_build/html",
+    )
+```
+
+### Documentation Review Checklist for Pull Requests
+
+When reviewing documentation changes in pull requests, verify:
+
+- [ ] Prose is clear, concise, and free of jargon (or jargon is defined)
+- [ ] Code examples are complete and runnable
+- [ ] Links point to stable URLs (not branch-specific or ephemeral)
+- [ ] Headings follow a logical hierarchy
+- [ ] New features have corresponding documentation
+- [ ] Removed features have documentation updated or removed
+- [ ] Screenshots or diagrams are current
+- [ ] Alt text is provided for all images
+
+## Resources
+
+### Official Documentation for Validation Tools
+- **Vale**: https://vale.sh/docs/
+- **HTMLProofer**: https://github.com/gjtorikian/html-proofer
+- **markdownlint**: https://github.com/DavidAnson/markdownlint
+- **markdownlint-cli2**: https://github.com/DavidAnson/markdownlint-cli2
+- **doc8**: https://github.com/PyCQA/doc8
+- **nbval**: https://github.com/computationalmodelling/nbval
+- **pytest-notebook**: https://github.com/chrisjsewell/pytest-notebook
+
+### Style Guides and Packages for Vale
+- **proselint**: https://github.com/errata-ai/proselint
+- **write-good**: https://github.com/errata-ai/write-good
+- **Google Developer Style**: https://github.com/errata-ai/Google
+- **Microsoft Style**: https://github.com/errata-ai/Microsoft
+
+### Language-Specific Documentation Resources
+- **Scientific Python Development Guide - Docs**: https://learn.scientific-python.org/development/guides/docs/
+- **Diataxis Framework**: https://diataxis.fr/
+- **NumPy Documentation Style**: https://numpydoc.readthedocs.io/en/latest/format.html
+- **Rust Documentation**: https://doc.rust-lang.org/rustdoc/
+- **R pkgdown**: https://pkgdown.r-lib.org/
+- **Go Documentation**: https://go.dev/doc/
+- **Julia Documenter.jl**: https://documenter.juliadocs.org/
+
+### GitHub Actions for Documentation
+- **Vale Action**: https://github.com/errata-ai/vale-action
+- **markdownlint-cli2-action**: https://github.com/DavidAnson/markdownlint-cli2-action
+- **markdown-link-check Action**: https://github.com/gaurav-nelson/github-action-markdown-link-check
+
+## Summary
+
+Documentation validation transforms documentation from an afterthought into a tested, reliable deliverable. By applying the same rigor to documentation that we apply to code -- version control, automated testing, linting, and CI -- we ensure that users and contributors can trust the documentation they read.
+
+**Key takeaways:**
+
+Use Vale for prose quality and style consistency across your documentation. Use HTMLProofer or Sphinx linkcheck to catch broken links before users encounter them. Test code examples with pytest doctest-glob and validate notebooks with nbval. Test setup instructions in clean Docker containers to catch "works on my machine" problems. Integrate all validation into GitHub Actions so every pull request is automatically checked. Use the handoff checklist to verify documentation completeness before project milestones.
+
+**Start here:** Install Vale and add it to your pre-commit hooks. This single step catches the most common documentation issues -- unclear prose, passive voice, jargon, and inconsistency -- before they ever reach a reviewer.

--- a/plugins/project-management/skills/documentation-validation/assets/vale-config.ini
+++ b/plugins/project-management/skills/documentation-validation/assets/vale-config.ini
@@ -1,0 +1,336 @@
+# =============================================================================
+# Vale Configuration for Scientific Python Documentation
+# =============================================================================
+#
+# This is a ready-to-use .vale.ini configuration file for scientific software
+# projects. Copy this file to your repository root as `.vale.ini` and then
+# run `vale sync` to download the configured style packages.
+#
+# Usage:
+#   1. Copy this file to your repository root:
+#      cp vale-config.ini /path/to/your/project/.vale.ini
+#
+#   2. Download style packages:
+#      vale sync
+#
+#   3. Run Vale:
+#      vale docs/
+#      vale README.md
+#
+# Prerequisites:
+#   - Vale installed: https://vale.sh/docs/vale-cli/installation/
+#   - macOS: brew install vale
+#   - Linux: snap install vale
+#
+# Customization:
+#   - Add project-specific accepted terms to .vale/styles/Vocab/Project/accept.txt
+#   - Add terms to reject to .vale/styles/Vocab/Project/reject.txt
+#   - Adjust MinAlertLevel to control verbosity (suggestion, warning, error)
+#   - Override specific rules per file pattern using [pattern] sections below
+#
+# =============================================================================
+
+# Where Vale stores downloaded styles and custom rules
+StylesPath = .vale/styles
+
+# Minimum severity level to report:
+#   suggestion - all findings (verbose, good for thorough review)
+#   warning    - warnings and errors (recommended for CI)
+#   error      - only errors (minimum friction)
+MinAlertLevel = warning
+
+# Style packages to download with `vale sync`
+# These are community-maintained rule sets
+Packages = proselint, write-good, Google
+
+# Vocabulary name for project-specific terminology
+# Create files at:
+#   .vale/styles/Vocab/Scientific/accept.txt  (terms to allow)
+#   .vale/styles/Vocab/Scientific/reject.txt  (terms to flag)
+Vocab = Scientific
+
+# =============================================================================
+# Global settings (apply to all supported file types)
+# =============================================================================
+
+[*]
+# Base styles to apply to all files
+# - Vale: built-in rules (spelling, capitalization, etc.)
+# - proselint: general writing best practices
+# - write-good: flags passive voice, weasel words, etc.
+BasedOnStyles = Vale, proselint, write-good
+
+# ---- Rule overrides ----
+# Disable rules that are too noisy for technical documentation
+
+# write-good.Passive: Flags passive voice. Scientific writing sometimes needs
+# passive voice ("the data were collected"), so we reduce to suggestion level.
+write-good.Passive = suggestion
+
+# write-good.Weasel: Flags imprecise words like "very", "really", "quite".
+# Keep as warning -- these weaken scientific documentation.
+write-good.Weasel = warning
+
+# write-good.TooWordy: Flags wordy phrases.
+# Keep as suggestion to avoid blocking CI on style preferences.
+write-good.TooWordy = suggestion
+
+# write-good.ThereIs: Flags "there is/there are" constructions.
+# Reduce to suggestion -- sometimes unavoidable in technical writing.
+write-good.ThereIs = suggestion
+
+# proselint.Cliches: Flags cliched expressions.
+# Keep as warning for professional documentation.
+proselint.Cliches = warning
+
+# proselint.Hedging: Flags hedging language ("I think", "perhaps").
+# Reduce to suggestion -- scientific writing may appropriately hedge.
+proselint.Hedging = suggestion
+
+# Vale.Spelling: Built-in spell checker.
+# Disable if using a separate spell checker or if too many false positives
+# from domain-specific terminology. The Vocab files handle known terms.
+Vale.Spelling = warning
+
+# =============================================================================
+# Markdown-specific settings
+# =============================================================================
+
+[*.md]
+BasedOnStyles = Vale, proselint, write-good
+
+# =============================================================================
+# reStructuredText-specific settings
+# =============================================================================
+
+[*.rst]
+BasedOnStyles = Vale, proselint, write-good
+
+# =============================================================================
+# Tutorial and getting-started content (more relaxed, conversational tone)
+# =============================================================================
+
+[docs/tutorials/*.md]
+BasedOnStyles = Vale, proselint, write-good
+# Tutorials can be more conversational, so relax some rules
+write-good.Passive = suggestion
+write-good.TooWordy = suggestion
+write-good.ThereIs = NO
+proselint.Hedging = NO
+
+[docs/getting-started/*.md]
+BasedOnStyles = Vale, proselint, write-good
+write-good.Passive = suggestion
+write-good.TooWordy = suggestion
+write-good.ThereIs = NO
+
+# =============================================================================
+# API reference docs (auto-generated content, minimal linting)
+# =============================================================================
+
+[docs/reference/*.md]
+BasedOnStyles = Vale
+# Auto-generated API docs have their own conventions; apply minimal rules
+write-good.Passive = NO
+write-good.Weasel = NO
+proselint.Cliches = NO
+
+[docs/reference/*.rst]
+BasedOnStyles = Vale
+write-good.Passive = NO
+write-good.Weasel = NO
+proselint.Cliches = NO
+
+# =============================================================================
+# Generated and third-party content (skip entirely)
+# =============================================================================
+
+[docs/_build/**]
+# Skip generated build output
+BasedOnStyles = NO
+
+[docs/generated/**]
+# Skip auto-generated content (e.g., autosummary output)
+BasedOnStyles = NO
+
+# =============================================================================
+# Changelog (relaxed rules -- changelogs have their own style)
+# =============================================================================
+
+[CHANGELOG.md]
+BasedOnStyles = Vale
+write-good.Passive = NO
+write-good.Weasel = NO
+write-good.TooWordy = NO
+proselint.Cliches = NO
+
+[CHANGES.rst]
+BasedOnStyles = Vale
+write-good.Passive = NO
+write-good.Weasel = NO
+write-good.TooWordy = NO
+proselint.Cliches = NO
+
+
+# =============================================================================
+# VOCABULARY FILES
+# =============================================================================
+#
+# After copying this .vale.ini to your project, create the vocabulary
+# directory and files:
+#
+#   mkdir -p .vale/styles/Vocab/Scientific
+#
+# Then create the following two files:
+#
+# --- .vale/styles/Vocab/Scientific/accept.txt ---
+# One term per line. These terms will not be flagged as misspellings.
+#
+#   NumPy
+#   SciPy
+#   pandas
+#   matplotlib
+#   xarray
+#   scikit-learn
+#   sklearn
+#   DataFrame
+#   ndarray
+#   dtype
+#   docstring
+#   docstrings
+#   boolean
+#   namespace
+#   namespaces
+#   reproducibility
+#   citable
+#   metadata
+#   conda
+#   pixi
+#   PyPI
+#   pytest
+#   pre-commit
+#   autosummary
+#   autodoc
+#   intersphinx
+#   numpydoc
+#   reStructuredText
+#   MyST
+#   Jupyter
+#   JupyterLab
+#   JupyterHub
+#   Sphinx
+#   MkDocs
+#   Diataxis
+#   Diátaxis
+#   pydata
+#   Astropy
+#   HoloViz
+#   Zarr
+#   Dask
+#   netCDF
+#   HDF5
+#   FITS
+#   API
+#   APIs
+#   CLI
+#   YAML
+#   TOML
+#   JSON
+#   RST
+#   CSV
+#   ORCID
+#   DOI
+#   Zenodo
+#   GitHub
+#   GitLab
+#   CI/CD
+#   DevOps
+#   linter
+#   linting
+#   config
+#   pre-configured
+#   plugin
+#   plugins
+#   backend
+#   frontend
+#   runtime
+#   async
+#   kwargs
+#   args
+#   venv
+#   virtualenv
+#   TODO
+#   Dockerfile
+#   pyproject
+#
+# --- .vale/styles/Vocab/Scientific/reject.txt ---
+# One term per line. These terms will always be flagged.
+# Useful for enforcing inclusive and precise language.
+#
+#   obviously
+#   trivially
+#   simply
+#   easy
+#   easily
+#   straightforward
+#   just
+#   of course
+#   clearly
+#   as everyone knows
+#   it is clear that
+#   needless to say
+#   any idiot
+#   dummy
+#   sanity check
+#   master/slave
+#   blacklist
+#   whitelist
+#
+# =============================================================================
+
+# =============================================================================
+# CUSTOM RULES
+# =============================================================================
+#
+# You can create project-specific rules in .vale/styles/Custom/.
+# Each rule is a YAML file. Examples:
+#
+# --- .vale/styles/Custom/ScientificAbbreviations.yml ---
+# extends: existence
+# message: "Expand '%s' on first use."
+# level: warning
+# scope: paragraph
+# tokens:
+#   - '\b[A-Z]{3,}\b'
+# exceptions:
+#   - API
+#   - URL
+#   - HTML
+#   - JSON
+#   - YAML
+#   - DOI
+#   - PDF
+#
+# --- .vale/styles/Custom/AvoidFutureWork.yml ---
+# extends: existence
+# message: "Avoid '%s' in documentation. Document what exists now."
+# level: warning
+# tokens:
+#   - 'will be implemented'
+#   - 'coming soon'
+#   - 'in a future release'
+#   - 'planned for'
+#   - 'not yet implemented'
+#
+# --- .vale/styles/Custom/CodeReferences.yml ---
+# extends: existence
+# message: "Use backticks for code references: `%s`"
+# level: suggestion
+# scope: paragraph
+# tokens:
+#   - '(?<![`])\b(True|False|None|pip install|import \w+)\b(?![`])'
+#
+# To use custom rules, add 'Custom' to your BasedOnStyles:
+#   BasedOnStyles = Vale, proselint, write-good, Custom
+#
+# =============================================================================

--- a/plugins/project-management/skills/documentation-validation/assets/validation-checklist.md
+++ b/plugins/project-management/skills/documentation-validation/assets/validation-checklist.md
@@ -1,0 +1,305 @@
+# Documentation Completeness Checklist
+
+A comprehensive checklist for validating that project documentation is complete, accurate, and ready for handoff. Use this checklist when preparing a project for release, transferring ownership to new maintainers, onboarding new team members, or auditing documentation health.
+
+**How to use this checklist:**
+- Copy this file into your project repository or issue tracker
+- Check off items as they are completed
+- Items marked **(Critical)** must be completed before any release or handoff
+- Items marked **(Recommended)** should be completed for mature projects
+- Items marked **(Scientific)** are specific to scientific/research software
+- Not every project needs every item -- skip categories that do not apply
+
+---
+
+## Essential Repository Files
+
+These files should exist at the root of the repository and are expected by the open-source community.
+
+- [ ] **(Critical)** `README.md` exists and contains:
+  - [ ] Project name and one-sentence description
+  - [ ] Badges for CI status, coverage, PyPI version, and license
+  - [ ] Installation instructions (at least one method)
+  - [ ] Minimal usage example (copy-paste-runnable)
+  - [ ] Link to full documentation
+  - [ ] Link to contributing guide
+  - [ ] License information
+- [ ] **(Critical)** `LICENSE` or `LICENSE.txt` exists with an appropriate open-source license
+  - [ ] License is OSI-approved (MIT, BSD-3-Clause, Apache-2.0, etc.)
+  - [ ] License year and copyright holder are correct
+- [ ] **(Critical)** `CONTRIBUTING.md` exists and contains:
+  - [ ] How to report bugs
+  - [ ] How to request features
+  - [ ] How to submit pull requests
+  - [ ] Development environment setup instructions
+  - [ ] Code style and quality expectations
+  - [ ] Code of conduct reference
+- [ ] **(Critical)** `CHANGELOG.md` or `CHANGES.rst` exists and contains:
+  - [ ] Entries for all released versions
+  - [ ] Categorized changes (Added, Changed, Deprecated, Removed, Fixed, Security)
+  - [ ] Date for each release
+  - [ ] Links to relevant pull requests or issues
+- [ ] **(Recommended)** `CODE_OF_CONDUCT.md` exists (Contributor Covenant or equivalent)
+- [ ] **(Recommended)** `SECURITY.md` exists with vulnerability reporting instructions
+- [ ] **(Recommended)** `.github/ISSUE_TEMPLATE/` directory with bug report and feature request templates
+- [ ] **(Recommended)** `.github/PULL_REQUEST_TEMPLATE.md` exists
+
+---
+
+## User Documentation
+
+Documentation that end users need to install, configure, and use the software.
+
+### Installation
+
+- [ ] **(Critical)** Installation instructions cover the primary method (the project's package manager)
+- [ ] **(Recommended)** Installation instructions cover alternative methods
+- [ ] **(Recommended)** System prerequisites are listed (Language/runtime version, OS, system libraries)
+- [ ] **(Recommended)** Instructions tested in a clean environment (Docker or fresh venv)
+- [ ] **(Recommended)** Troubleshooting section for common installation issues
+- [ ] **(Scientific)** Instructions for installing optional heavy dependencies (GPU, MPI, etc.)
+
+### Quickstart / Getting Started
+
+- [ ] **(Critical)** Quickstart guide exists (path to first meaningful result in under 5 minutes)
+- [ ] **(Critical)** Quickstart code examples are copy-paste-runnable
+- [ ] **(Recommended)** Quickstart uses realistic but minimal data
+- [ ] **(Recommended)** Expected output is shown alongside code examples
+- [ ] **(Recommended)** Quickstart links to deeper tutorials for next steps
+
+### Tutorials
+
+- [ ] **(Critical)** At least one tutorial exists for the primary use case
+- [ ] **(Recommended)** Tutorials progress from simple to complex
+- [ ] **(Recommended)** Tutorials use the Diataxis "learning-oriented" style
+- [ ] **(Recommended)** Tutorials include complete, working code (not fragments)
+- [ ] **(Recommended)** Tutorials explain the "why" alongside the "how"
+- [ ] **(Scientific)** Tutorials use realistic scientific data or scenarios
+- [ ] **(Scientific)** Tutorials include visualization of results where applicable
+
+### How-to Guides
+
+- [ ] **(Recommended)** Common tasks have dedicated how-to guides
+- [ ] **(Recommended)** How-to guides are goal-oriented and practical
+- [ ] **(Recommended)** How-to guides assume the reader has basic familiarity
+- [ ] **(Recommended)** How-to guides link to relevant API reference
+
+### API Reference
+
+- [ ] **(Critical)** All public modules, classes, and functions are documented
+- [ ] **(Critical)** Docstrings follow a consistent style (the project's standard docstring/comment style)
+- [ ] **(Critical)** Parameters, return values, and types are documented
+- [ ] **(Recommended)** Docstrings include at least one usage example
+- [ ] **(Recommended)** Deprecated functions are marked with deprecation warnings
+- [ ] **(Recommended)** Cross-references link to related functions and classes
+- [ ] **(Recommended)** API documentation is auto-generated from source (autodoc/mkdocstrings)
+
+### Configuration Reference
+
+- [ ] **(Recommended)** All configuration options are documented
+- [ ] **(Recommended)** Default values are listed
+- [ ] **(Recommended)** Environment variables are documented
+- [ ] **(Recommended)** Example configuration files are provided
+
+### CLI Reference (if applicable)
+
+- [ ] **(Critical)** All commands and subcommands are documented
+- [ ] **(Critical)** All flags and options have descriptions
+- [ ] **(Recommended)** Usage examples for common workflows
+- [ ] **(Recommended)** Auto-generated from CLI help text where possible
+
+---
+
+## Developer Documentation
+
+Documentation that contributors need to understand, build, test, and extend the software.
+
+### Architecture Overview
+
+- [ ] **(Recommended)** High-level architecture diagram exists
+- [ ] **(Recommended)** Major components and their responsibilities are described
+- [ ] **(Recommended)** Data flow between components is documented
+- [ ] **(Recommended)** Key design decisions and their rationale are recorded
+- [ ] **(Recommended)** External dependencies and their purposes are listed
+
+### Development Environment Setup
+
+- [ ] **(Critical)** Step-by-step development setup instructions exist
+- [ ] **(Critical)** Instructions cover cloning, installing dependencies, and running tests
+- [ ] **(Recommended)** Instructions cover IDE/editor setup (VS Code, PyCharm)
+- [ ] **(Recommended)** Instructions for pre-commit hook installation
+- [ ] **(Recommended)** Instructions verified in a clean environment
+
+### Testing Guide
+
+- [ ] **(Critical)** How to run the full test suite
+- [ ] **(Critical)** How to run a subset of tests
+- [ ] **(Recommended)** How to write new tests (conventions, fixtures, patterns)
+- [ ] **(Recommended)** Test organization and naming conventions
+- [ ] **(Recommended)** How CI runs tests (matrix, environments)
+- [ ] **(Recommended)** Coverage expectations and how to check coverage
+
+### Release Process
+
+- [ ] **(Critical)** Step-by-step release process is documented
+- [ ] **(Critical)** Version numbering scheme is documented (semver, calver, etc.)
+- [ ] **(Recommended)** Changelog update process is documented
+- [ ] **(Recommended)** Release automation (CI/CD) is documented
+- [ ] **(Recommended)** Post-release verification steps are listed
+- [ ] **(Recommended)** Who has release permissions is documented
+
+### Dependency Management
+
+- [ ] **(Recommended)** How to add, update, and remove dependencies
+- [ ] **(Recommended)** Pinning strategy is documented (exact pins, ranges, lock files)
+- [ ] **(Recommended)** How to handle security updates
+- [ ] **(Recommended)** Optional vs. required dependencies are explained
+
+---
+
+## Project Health
+
+Indicators that the project infrastructure is working and documented.
+
+### CI/CD Pipeline
+
+- [ ] **(Critical)** CI runs on pull requests and passes
+- [ ] **(Critical)** CI configuration files exist and are readable
+- [ ] **(Recommended)** CI matrix covers supported Python versions and OS
+- [ ] **(Recommended)** CI includes linting, type checking, and documentation builds
+- [ ] **(Recommended)** CI failure modes are documented (what a red check means)
+- [ ] **(Recommended)** Deployment/release pipeline is documented
+
+### Code Quality
+
+- [ ] **(Recommended)** Linter is configured and documented (the project's linter)
+- [ ] **(Recommended)** Formatter is configured and documented (the project's formatter)
+- [ ] **(Recommended)** Type checker is configured and documented (the project's type checker, if applicable)
+- [ ] **(Recommended)** Pre-commit hooks are configured
+- [ ] **(Recommended)** Code quality expectations are in CONTRIBUTING.md
+
+### Documentation Build
+
+- [ ] **(Critical)** Documentation builds without errors or warnings
+- [ ] **(Critical)** Documentation is deployed and accessible at a public URL
+- [ ] **(Recommended)** Documentation builds are part of CI
+- [ ] **(Recommended)** Documentation versioning is configured (if multiple versions exist)
+- [ ] **(Recommended)** Documentation uses a responsive, accessible theme
+
+---
+
+## Scientific Software Specific
+
+Additional requirements for software used in research contexts.
+
+### Citation
+
+- [ ] **(Scientific)** `CITATION.cff` exists in the repository root
+- [ ] **(Scientific)** CITATION.cff is valid (check with `cffconvert --validate`)
+- [ ] **(Scientific)** BibTeX citation is provided in documentation
+- [ ] **(Scientific)** DOI is registered (Zenodo, etc.)
+- [ ] **(Scientific)** ORCID identifiers are included for authors
+- [ ] **(Scientific)** Citation instructions are in README and documentation
+
+### Data Access and Formats
+
+- [ ] **(Scientific)** Sample/test data is documented and accessible
+- [ ] **(Scientific)** Input data formats are documented with examples
+- [ ] **(Scientific)** Output data formats are documented with examples
+- [ ] **(Scientific)** Data download instructions are provided (if external data required)
+- [ ] **(Scientific)** Data size and storage requirements are documented
+- [ ] **(Scientific)** Data licenses are documented
+
+### Reproducibility
+
+- [ ] **(Scientific)** Environment specification is provided (the project's dependency specification files, e.g., requirements.txt, environment.yml, Cargo.lock, package-lock.json)
+- [ ] **(Scientific)** Pinned/locked dependency versions are available
+- [ ] **(Scientific)** Random seeds are documented for stochastic processes
+- [ ] **(Scientific)** Hardware requirements are documented (RAM, GPU, disk)
+- [ ] **(Scientific)** Expected runtime for common tasks is documented
+- [ ] **(Scientific)** Instructions to reproduce published results are provided
+
+### Methodology
+
+- [ ] **(Scientific)** Algorithms and methods are described or referenced
+- [ ] **(Scientific)** Mathematical notation is rendered correctly
+- [ ] **(Scientific)** Assumptions and limitations are documented
+- [ ] **(Scientific)** Validation against known results is documented
+- [ ] **(Scientific)** Units and coordinate systems are documented
+
+---
+
+## Onboarding Documentation
+
+Documentation specifically for new team members or contributors joining the project.
+
+### Getting Started as a Developer
+
+- [ ] **(Recommended)** "Day one" guide for new contributors exists
+- [ ] **(Recommended)** Guide covers: clone, install, run tests, make a change, submit PR
+- [ ] **(Recommended)** Guide links to deeper documentation for each step
+- [ ] **(Recommended)** Common "first issues" or "good first issue" labels are used
+- [ ] **(Recommended)** Mentorship or review process for new contributors is described
+
+### Key Contacts and Communication
+
+- [ ] **(Recommended)** Primary maintainers are listed with contact information
+- [ ] **(Recommended)** Communication channels are documented (Slack, Discourse, mailing list)
+- [ ] **(Recommended)** Meeting schedule and notes location (if applicable)
+- [ ] **(Recommended)** Decision-making process is documented
+- [ ] **(Recommended)** Governance model is documented (for larger projects)
+
+### Glossary and Context
+
+- [ ] **(Recommended)** Glossary of project-specific terms and abbreviations
+- [ ] **(Scientific)** Glossary of domain-specific terminology
+- [ ] **(Recommended)** List of acronyms used in the codebase
+- [ ] **(Recommended)** Links to background reading or prerequisite knowledge
+- [ ] **(Recommended)** Project history and motivation summary
+
+### Known Issues and Technical Debt
+
+- [ ] **(Recommended)** Known issues are documented (or linked to issue tracker)
+- [ ] **(Recommended)** Technical debt is catalogued with severity and impact
+- [ ] **(Recommended)** Planned deprecations are documented with timelines
+- [ ] **(Recommended)** Workarounds for known issues are documented
+- [ ] **(Recommended)** Areas of the codebase that need refactoring are identified
+
+### Decision Log
+
+- [ ] **(Recommended)** Major architectural decisions are recorded (ADRs or similar)
+- [ ] **(Recommended)** Each decision includes context, decision, and consequences
+- [ ] **(Recommended)** Alternatives considered are documented
+- [ ] **(Recommended)** Decisions are dated and attributed
+
+---
+
+## Validation Automation
+
+Checks that can be automated in CI to continuously verify documentation quality.
+
+- [ ] Documentation builds without warnings (`sphinx-build -W`)
+- [ ] All internal links resolve
+- [ ] External links checked on schedule (weekly)
+- [ ] Prose passes Vale linting
+- [ ] Markdown passes markdownlint checks
+- [ ] Code examples in documentation execute successfully (doctest)
+- [ ] Jupyter notebooks execute successfully (nbval)
+- [ ] API reference coverage matches public API surface
+- [ ] No references to deprecated functions or removed features
+- [ ] CITATION.cff is valid
+
+---
+
+## Scoring Guide
+
+Use this scoring guide to assess overall documentation readiness:
+
+| Level | Criteria | Suitable For |
+|-------|----------|-------------|
+| **Minimal** | All **(Critical)** items checked | Internal/prototype projects |
+| **Good** | All **(Critical)** + 50% of **(Recommended)** | Open-source release |
+| **Excellent** | All **(Critical)** + 80% of **(Recommended)** | Community project handoff |
+| **Exemplary** | All items checked including **(Scientific)** | Published research software |
+
+**Tip:** Track your score over time. Aim to move up one level with each release cycle.

--- a/plugins/project-management/skills/documentation-validation/references/DOCUMENTATION_STANDARDS.md
+++ b/plugins/project-management/skills/documentation-validation/references/DOCUMENTATION_STANDARDS.md
@@ -1,0 +1,444 @@
+# Documentation Standards for Research Software
+
+Comprehensive reference for documentation frameworks, completeness criteria,
+and quality metrics applied to research software projects in any language.
+
+**Backlinks:** Used by the `documentation-validation` skill and the
+`documentation-validator` agent when auditing documentation completeness.
+Also referenced by the `project-onboarding-specialist` agent when scaffolding
+new project documentation.
+
+## Table of Contents
+
+| Line | Section | Description |
+|------|---------|-------------|
+| 29   | The Diataxis Framework | Four documentation types: tutorials, how-to, reference, explanation |
+| 95   | Applying Diataxis | Mapping the framework to research software documentation |
+| 150  | Completeness Criteria | What "complete documentation" means at each maturity level |
+| 215  | README Standards | What makes a great README for research software |
+| 275  | API Documentation | Standards for function/class/module reference docs |
+| 320  | Readability Metrics | Flesch-Kincaid, sentence length, and practical guidelines |
+| 360  | Documentation Debt | Identifying, measuring, and reducing documentation debt |
+| 400  | The Documentation System | docs-as-code, build tools, hosting |
+| 445  | Accessibility | Making documentation accessible to all users |
+| 480  | Internationalization | Supporting non-English documentation |
+| 500  | Quality Checklist | Quick pass/fail checklist for documentation reviews |
+| 530  | External Resources | Frameworks, guides, and community standards |
+
+---
+
+## The Diataxis Framework
+
+Diataxis (from Greek: "across" + "arrangement") organizes documentation into
+four types based on two axes: what the user needs (learning vs. working) and
+how the content is structured (practical vs. theoretical).
+
+```
+                    PRACTICAL                  THEORETICAL
+                ┌─────────────────┬─────────────────────┐
+                │                 │                     │
+   LEARNING     │   TUTORIALS     │    EXPLANATION      │
+   (study)      │   Learning-     │    Understanding-   │
+                │   oriented      │    oriented         │
+                │                 │                     │
+                ├─────────────────┼─────────────────────┤
+                │                 │                     │
+   WORKING      │   HOW-TO        │    REFERENCE        │
+   (apply)      │   Task-         │    Information-     │
+                │   oriented      │    oriented         │
+                │                 │                     │
+                └─────────────────┴─────────────────────┘
+```
+
+### Tutorials
+
+**Purpose:** Help a newcomer learn by doing. Walk them through a complete
+experience with guaranteed success.
+
+**Characteristics:**
+- Learning-oriented, not task-oriented
+- Follows a specific sequence of steps
+- Works on first attempt (tested instructions)
+- Builds confidence — avoids choices and digressions
+- Focuses on concrete actions, not abstract concepts
+- Has a meaningful result the learner can see
+
+**Research software example:** "Analyze your first FITS file with astropy"
+— walks through opening a file, reading headers, plotting data.
+
+### How-To Guides
+
+**Purpose:** Help a practitioner accomplish a specific task. Assumes basic
+knowledge.
+
+**Characteristics:**
+- Task-oriented ("How to X")
+- Addresses a specific real-world need
+- Assumes the reader knows the basics
+- Flexible — allows the reader to adapt to their situation
+- Can reference other how-to guides
+- Ordered by the task's logical steps, not by concepts
+
+**Research software example:** "How to mask bad pixels in your data
+reduction pipeline" — addresses a specific need, assumes familiarity
+with the tool.
+
+### Reference
+
+**Purpose:** Provide accurate, comprehensive technical information for
+users who already know what they're looking for.
+
+**Characteristics:**
+- Information-oriented
+- Comprehensive and accurate above all else
+- Structured by the code itself (classes, functions, modules)
+- Terse and precise (not conversational)
+- Kept in sync with the code (often auto-generated)
+- Does not explain concepts or teach — just documents what exists
+
+**Research software example:** API reference generated from docstrings:
+function signatures, parameter types, return values, exceptions.
+
+### Explanation
+
+**Purpose:** Provide understanding. Explain why things work the way they do.
+
+**Characteristics:**
+- Understanding-oriented
+- Discusses concepts, design decisions, alternatives, history
+- Can be opinionated ("We chose X because...")
+- Provides context that helps users make their own decisions
+- Does not include step-by-step instructions
+- May reference academic papers, algorithms, or domain concepts
+
+**Research software example:** "How the coordinate transformation system
+works" — explains the mathematical framework, design choices, and
+trade-offs.
+
+## Applying Diataxis
+
+### Mapping to Research Software Documentation
+
+| Diataxis Type | Common Locations | Examples |
+|--------------|-----------------|----------|
+| Tutorials | `docs/tutorials/`, README quickstart | "Getting started with X", "Your first analysis" |
+| How-To | `docs/how-to/`, FAQ, cookbook | "How to configure parallel processing", "How to export to HDF5" |
+| Reference | `docs/api/`, auto-generated docs | API reference, configuration options, CLI flags |
+| Explanation | `docs/explanation/`, architecture docs | "Design decisions", "How the solver works", "Data model" |
+
+### Where Each Type Lives
+
+**README.md** should contain:
+- A mini-tutorial (quickstart section)
+- Links to full tutorials and how-to guides
+- Brief explanation of what the project does and why
+
+**CONTRIBUTING.md** should contain:
+- How-to guides for contributing (how to set up, how to test, how to submit)
+- Reference for code style and conventions
+- Explanation of the project's development philosophy
+
+**Dedicated docs/ directory** should contain:
+- Full tutorials for learning
+- How-to guides for common tasks
+- Auto-generated API reference
+- Explanation of architecture and design decisions
+
+### Common Anti-Patterns
+
+1. **Tutorial that's actually reference.** Listing every function parameter
+   in a "getting started" guide. Keep tutorials focused on the happy path.
+
+2. **How-to guide that's actually a tutorial.** A "How to query the database"
+   guide that starts with "First, install the package..." — skip basics in
+   how-to guides.
+
+3. **Reference with too much explanation.** Function docstrings that include
+   three paragraphs of theory. Put theory in explanation docs and link to it.
+
+4. **Explanation that's actually a how-to.** "Understanding configuration"
+   that's really "How to configure X." Rename it and restructure.
+
+## Completeness Criteria
+
+### Level 1: Minimum Viable Documentation
+
+Every project, no matter how small, must have:
+
+- [ ] README with: what it does, how to install, basic usage example
+- [ ] LICENSE file
+- [ ] Installation instructions that work on first attempt
+
+### Level 2: Contributor-Ready
+
+Projects that accept contributions need:
+
+- [ ] Everything in Level 1
+- [ ] CONTRIBUTING.md with development setup instructions
+- [ ] At least one tutorial or getting-started guide
+- [ ] API reference for public functions/classes
+- [ ] CHANGELOG or release notes
+
+### Level 3: Production-Ready
+
+Projects used in production or by external teams:
+
+- [ ] Everything in Levels 1-2
+- [ ] CODE_OF_CONDUCT.md
+- [ ] SECURITY.md
+- [ ] CITATION.cff (for research software)
+- [ ] How-to guides for common tasks
+- [ ] Configuration reference
+- [ ] Error message documentation or troubleshooting guide
+- [ ] Versioned documentation (matching software versions)
+
+### Level 4: Community-Sustained
+
+Projects with active community adoption:
+
+- [ ] Everything in Levels 1-3
+- [ ] Architecture/design explanation docs
+- [ ] Migration guides between major versions
+- [ ] FAQ or discussions
+- [ ] Multiple tutorials for different audiences
+- [ ] Localized documentation (if international audience)
+- [ ] Accessibility compliance
+
+### Assessing Current Level
+
+To determine a project's documentation level, use the
+`assets/validation-checklist.md` for a detailed item-by-item assessment.
+
+## README Standards
+
+A research software README should follow this structure:
+
+### Essential Sections (in order)
+
+1. **Title and Badges** — Project name, CI status, version, license
+2. **One-Sentence Description** — What the project does (not how)
+3. **Key Features** — 3-5 bullet points of core capabilities
+4. **Installation** — Primary install method, must work on first attempt
+5. **Quick Start** — Minimal working example (5-15 lines of code)
+6. **Documentation Link** — Link to full docs if they exist
+7. **Contributing** — Link to CONTRIBUTING.md
+8. **Citation** — How to cite (link to CITATION.cff)
+9. **License** — License name and link to LICENSE file
+
+### Quality Signals
+
+**Good README characteristics:**
+- Installation instructions succeed on first attempt in a clean environment
+- Quick start example runs without modification and produces meaningful output
+- Each section is complete and self-contained
+- Links to external docs are not broken
+- Domain-specific terms are defined or linked on first use
+
+**README anti-patterns:**
+- Installation instructions skip prerequisites
+- Quick start example requires undocumented dependencies
+- "See docs for details" without a working link
+- Badges for services that aren't actually configured
+- More than 50% of the README is API documentation
+
+### README Length Guide
+
+| Project Stage | Recommended Length |
+|--------------|-------------------|
+| Alpha / internal | 50-100 lines |
+| Beta / public | 100-250 lines |
+| Stable / released | 150-400 lines |
+
+If your README exceeds 400 lines, move content to dedicated documentation.
+
+## API Documentation
+
+### Documentation Coverage Goals
+
+| Level | Coverage |
+|-------|---------|
+| Minimum | All public functions have a one-line summary |
+| Good | All public functions have parameters, returns, and examples |
+| Excellent | All public functions have parameters, returns, raises, examples, and cross-references |
+
+### Language-Agnostic Standards
+
+Regardless of language, every public API element should document:
+
+1. **Summary** — One-line description of what it does
+2. **Parameters** — Name, type, description, default value
+3. **Returns** — Type and description of return value
+4. **Errors/Exceptions** — What errors can be raised and when
+5. **Examples** — At least one working example
+6. **See Also** — Links to related functions or concepts
+
+### Language-Specific Conventions
+
+| Language | Convention | Tool |
+|----------|-----------|------|
+| Python | NumPy-style or Google-style docstrings | Sphinx + autodoc |
+| Rust | `///` doc comments with examples | rustdoc |
+| R | roxygen2 comments | pkgdown |
+| Julia | `\"\"\"` docstrings | Documenter.jl |
+| Go | `//` comments on exported symbols | godoc |
+| C/C++ | Doxygen comments | Doxygen |
+| JavaScript/TypeScript | JSDoc comments | TypeDoc |
+
+## Readability Metrics
+
+### Flesch-Kincaid Grade Level
+
+Target: **Grade 8-12** for technical documentation. Research papers often
+score 14-18; documentation should be more accessible.
+
+Formula: `0.39 * (words/sentences) + 11.8 * (syllables/words) - 15.59`
+
+### Practical Readability Guidelines
+
+| Metric | Target | Why |
+|--------|--------|-----|
+| Average sentence length | 15-25 words | Shorter sentences are easier to parse |
+| Paragraph length | 3-5 sentences | Long paragraphs lose readers |
+| Heading frequency | Every 200-400 words | Headings provide navigation and structure |
+| Code example frequency | Every 300-500 words | Examples anchor abstract concepts |
+| Passive voice usage | <20% of sentences | Active voice is clearer and more direct |
+| Jargon density | Define on first use | New readers need definitions |
+
+### Measuring Readability
+
+Vale's `proselint` and `write-good` styles catch many readability issues.
+For quantitative measurement:
+
+- **Vale:** Built-in readability metrics via custom rules
+- **Hemingway Editor:** Web-based readability analysis (hemingwayapp.com)
+- **readability-score (npm):** CLI tool for batch readability analysis
+
+## Documentation Debt
+
+### What Is Documentation Debt?
+
+Documentation debt accumulates when:
+- Features are added without documentation
+- APIs change but docs are not updated
+- Setup instructions become outdated
+- Code examples reference removed functionality
+
+### Measuring Documentation Debt
+
+**Coverage ratio:** `documented_public_symbols / total_public_symbols`
+
+**Freshness score:** Compare documentation last-modified dates to code
+last-modified dates. Stale documentation (docs older than code) is a debt
+indicator.
+
+**Broken link count:** Number of internal and external broken links.
+
+**Setup success rate:** Can a new contributor follow the setup instructions
+and run tests on first attempt?
+
+### Reducing Documentation Debt
+
+1. **Add doc checks to CI** — Fail builds when public API lacks documentation
+2. **Require docs in PR checklist** — No feature without documentation
+3. **Schedule doc sprints** — Dedicated time for documentation improvement
+4. **Track doc issues** — Label documentation issues and triage them
+5. **Auto-generate what you can** — API reference should come from code
+
+## The Documentation System
+
+### docs-as-code
+
+Treat documentation like code:
+- Store in version control alongside code
+- Review in pull requests
+- Build and deploy automatically
+- Test (links, examples, linting)
+
+### Build Tools by Language
+
+| Language | Build Tool | Hosting |
+|----------|-----------|---------|
+| Python | Sphinx, MkDocs | ReadTheDocs, GitHub Pages |
+| Rust | rustdoc, mdBook | docs.rs, GitHub Pages |
+| R | pkgdown | GitHub Pages |
+| Julia | Documenter.jl | GitHub Pages |
+| Go | godoc | pkg.go.dev |
+| JavaScript | Docusaurus, TypeDoc | Vercel, Netlify |
+| Any | Jupyter Book | GitHub Pages, ReadTheDocs |
+
+### Versioned Documentation
+
+For libraries with multiple supported versions, serve versioned docs:
+- ReadTheDocs supports versioning natively
+- GitHub Pages can use subdirectories (`/v1/`, `/v2/`)
+- Include a version switcher in the documentation UI
+
+## Accessibility
+
+### WCAG Guidelines for Documentation
+
+- **Text alternatives** for images (alt text on diagrams, described figures)
+- **Color contrast** of at least 4.5:1 for body text
+- **Keyboard navigation** in documentation sites (skip links, focus management)
+- **Semantic HTML** in generated documentation (proper heading hierarchy)
+- **Readable fonts** at default browser size (minimum 16px body text)
+
+### Research-Specific Accessibility
+
+- **Figure descriptions** for plots and data visualizations
+- **Mathematical notation** in accessible formats (MathJax/KaTeX, not images)
+- **Code examples** with syntax highlighting that works with screen readers
+- **Table summaries** for data tables
+
+## Internationalization
+
+For projects with international audiences:
+
+- **Write in simple English** — avoid idioms, colloquialisms, and cultural references
+- **Use consistent terminology** — create and maintain a glossary
+- **Support translation** — use tools like Sphinx's i18n support or Crowdin
+- **Mark translatable strings** — separate prose from code in documentation
+- **Date/number formats** — use ISO 8601 dates and specify units
+
+## Quality Checklist
+
+Quick pass/fail checklist for documentation reviews:
+
+### Structure
+- [ ] README exists with installation, quickstart, and links to full docs
+- [ ] CONTRIBUTING exists with development setup
+- [ ] Documentation is organized by Diataxis type (or equivalent)
+- [ ] Navigation is clear and consistent
+
+### Content
+- [ ] All public APIs are documented
+- [ ] At least one tutorial exists for getting started
+- [ ] Code examples run without modification
+- [ ] Domain-specific terms are defined
+- [ ] Error messages are documented or searchable
+
+### Quality
+- [ ] No broken links (internal or external)
+- [ ] Prose passes Vale linting with minimal issues
+- [ ] Sentences average under 25 words
+- [ ] Headings appear every 200-400 words
+- [ ] Documentation is current with the latest release
+
+### Maintenance
+- [ ] Documentation is in version control
+- [ ] Doc quality checks run in CI
+- [ ] PRs include documentation updates when needed
+- [ ] Stale documentation is flagged and updated regularly
+
+## External Resources
+
+- [Diataxis Framework](https://diataxis.fr/) — The definitive guide to documentation structure
+- [Write the Docs](https://www.writethedocs.org/) — Community and resources for documentarians
+- [Google Technical Writing Courses](https://developers.google.com/tech-writing) — Free technical writing courses
+- [The Turing Way: Documentation](https://the-turing-way.netlify.app/reproducible-research/rdm.html) — Research documentation best practices
+- [Scientific Python Development Guide: Docs](https://learn.scientific-python.org/development/guides/docs/) — Python-specific documentation guidance
+- [JOSS Review Criteria](https://joss.readthedocs.io/en/latest/review_criteria.html) — What JOSS reviewers check for documentation
+- [ReadTheDocs](https://readthedocs.org/) — Free documentation hosting
+- [Keep a Changelog](https://keepachangelog.com/) — Changelog format standard
+- [Hemingway Editor](https://hemingwayapp.com/) — Readability analysis tool
+- [WCAG 2.1 Guidelines](https://www.w3.org/TR/WCAG21/) — Web accessibility standards

--- a/plugins/project-management/skills/documentation-validation/references/VALE_CONFIGURATION.md
+++ b/plugins/project-management/skills/documentation-validation/references/VALE_CONFIGURATION.md
@@ -1,0 +1,653 @@
+# Vale Configuration Reference
+
+Complete reference for configuring Vale as a prose linter for research
+software documentation. Covers installation, configuration, style packages,
+custom rules, and CI integration.
+
+**Backlinks:** Used by the `documentation-validation` skill and the
+`documentation-validator` agent when setting up or troubleshooting Vale.
+Also referenced by the `community-health-files` skill for prose quality
+in community health files.
+
+## Table of Contents
+
+| Line | Section | Description |
+|------|---------|-------------|
+| 30   | Quick Start | Install Vale and run your first check in 60 seconds |
+| 60   | .vale.ini Configuration | Complete config file reference with all options |
+| 120  | Style Packages | Available style packages and when to use each |
+| 195  | Style Selection Guide | Decision matrix for choosing styles |
+| 225  | Custom Rules | Writing project-specific Vale rules (substitution, existence, etc.) |
+| 320  | Vocabulary | Project-specific term lists: accept and reject |
+| 365  | Scoping and File Types | Control which files and sections Vale checks |
+| 405  | Integration | Editor plugins, pre-commit hooks, GitHub Actions |
+| 460  | Configuration Recipes | Ready-to-use configs for common documentation scenarios |
+| 510  | Troubleshooting | Common issues and how to fix them |
+| 545  | External Resources | Vale docs, style package repos, community resources |
+
+---
+
+## Quick Start
+
+```bash
+# Install Vale
+# macOS
+brew install vale
+
+# Linux (snap)
+sudo snap install vale
+
+# Any platform (with Go)
+go install github.com/errata-ai/vale/v3/cmd/vale@latest
+
+# Any platform (pre-built binary)
+# Download from https://github.com/errata-ai/vale/releases
+```
+
+Create a minimal `.vale.ini` in your project root:
+
+```ini
+StylesPath = .vale/styles
+MinAlertLevel = suggestion
+
+Packages = proselint, write-good
+
+[*.md]
+BasedOnStyles = Vale, proselint, write-good
+```
+
+Run Vale:
+
+```bash
+# Sync style packages (run once, and after changing Packages)
+vale sync
+
+# Lint all markdown files
+vale docs/
+vale README.md CONTRIBUTING.md
+
+# Lint with specific output format
+vale --output=JSON docs/
+```
+
+## .vale.ini Configuration
+
+The `.vale.ini` (or `_vale.ini` on Windows) file configures Vale's behavior.
+It uses INI format with global options and per-file-type sections.
+
+### Global Options
+
+```ini
+# Where Vale stores downloaded style packages
+StylesPath = .vale/styles
+
+# Minimum alert level to display: suggestion, warning, error
+MinAlertLevel = suggestion
+
+# Style packages to download (space or comma separated)
+Packages = proselint, write-good, Google
+
+# Vocabulary name (see line 320)
+Vocab = MyProject
+```
+
+### File Type Sections
+
+Sections use glob patterns to match files:
+
+```ini
+# Apply to all Markdown files
+[*.md]
+BasedOnStyles = Vale, proselint, write-good
+
+# Apply to reStructuredText files
+[*.rst]
+BasedOnStyles = Vale, write-good
+
+# Apply to specific directories
+[docs/tutorials/*.md]
+BasedOnStyles = Vale, Google
+# Override: disable a specific rule in tutorials
+Google.Passive = NO
+
+# Apply to HTML files
+[*.html]
+BasedOnStyles = Vale, proselint
+```
+
+### Rule Overrides
+
+Control individual rules within a section:
+
+```ini
+[*.md]
+BasedOnStyles = Vale, proselint, write-good
+
+# Disable a rule entirely
+write-good.Passive = NO
+
+# Downgrade a rule from error to warning
+Vale.Spelling = warning
+
+# Upgrade a rule from suggestion to error
+proselint.Cliches = error
+```
+
+Override levels: `YES` (enable at default level), `NO` (disable),
+`suggestion`, `warning`, `error`.
+
+### Ignore Patterns
+
+```ini
+# Ignore code blocks in Markdown
+# (Vale does this automatically for fenced code blocks)
+
+# Ignore specific file patterns
+[!docs/generated/**]
+# Files in docs/generated/ are not checked
+```
+
+### Transform Options
+
+```ini
+[*.md]
+# Treat Markdown as HTML after conversion
+Transform = md-to-html
+
+# For AsciiDoc files
+[*.adoc]
+Transform = adoc-to-html
+```
+
+## Style Packages
+
+Style packages are collections of rules. Install them via `Packages` in
+`.vale.ini` and download with `vale sync`.
+
+### proselint
+
+General-purpose writing style checks based on expert writing advice.
+
+```ini
+Packages = proselint
+[*.md]
+BasedOnStyles = proselint
+```
+
+**What it checks:**
+- Cliches and mixed metaphors
+- Redundancy ("advance planning", "end result")
+- Jargon and unnecessarily complex language
+- Hedging ("somewhat", "possibly")
+- Sexism and bias in language
+
+**Best for:** General documentation, README files, user guides.
+
+**Alert level:** Mostly warnings and suggestions. Not overly strict.
+
+### write-good
+
+Naive linter for English prose, focused on readability.
+
+```ini
+Packages = write-good
+[*.md]
+BasedOnStyles = write-good
+```
+
+**What it checks:**
+- Passive voice
+- Weasel words ("many", "various", "very")
+- "There is/There are" constructions
+- Adverb overuse
+- Wordy phrases
+
+**Best for:** First-pass readability improvement. Good for catching
+passive voice in scientific writing.
+
+**Caveat:** Can be noisy for technical documentation where passive voice
+is sometimes appropriate (e.g., "The function is called with...").
+Consider `write-good.Passive = NO` if false positives are excessive.
+
+### Google
+
+Google's developer documentation style guide.
+
+```ini
+Packages = Google
+[*.md]
+BasedOnStyles = Google
+```
+
+**What it checks:**
+- Use of "please" and "sorry" (avoid in technical docs)
+- Contractions (use them — more natural)
+- Second person ("you") vs. first person ("we")
+- Sentence length and complexity
+- Specific word choices (e.g., "click" vs "click on")
+- Oxford commas
+- Heading capitalization
+
+**Best for:** Developer-facing documentation, API docs, tutorials.
+
+**Caveat:** Opinionated about style. May conflict with academic writing
+conventions. Best for developer docs, not research papers.
+
+### Microsoft
+
+Microsoft's writing style guide.
+
+```ini
+Packages = Microsoft
+[*.md]
+BasedOnStyles = Microsoft
+```
+
+**What it checks:** Similar to Google but with Microsoft-specific preferences.
+More comprehensive vocabulary and terminology checks.
+
+**Best for:** Windows-focused documentation, Azure/cloud docs.
+
+### alex
+
+Checks for insensitive or inconsiderate writing.
+
+```ini
+Packages = alex
+[*.md]
+BasedOnStyles = alex
+```
+
+**What it checks:**
+- Gendered language
+- Ableist language
+- Racial or ethnic bias
+- LGBTQ+ insensitivity
+
+**Best for:** Ensuring inclusive language in community-facing documentation
+(README, CONTRIBUTING, CODE_OF_CONDUCT).
+
+## Style Selection Guide
+
+Choose styles based on your documentation type:
+
+| Documentation Type | Recommended Styles |
+|-------------------|-------------------|
+| README / CONTRIBUTING | `Vale, proselint, write-good` |
+| API reference docs | `Vale, Google` |
+| Tutorials / how-to | `Vale, Google, write-good` |
+| Research paper / methods | `Vale, proselint` (fewer false positives) |
+| Community files (CoC, Security) | `Vale, proselint, alex` |
+| All documentation | `Vale, proselint` (safe default) |
+
+**Starting recommendation for research software:**
+
+```ini
+Packages = proselint, write-good
+
+[*.md]
+BasedOnStyles = Vale, proselint, write-good
+write-good.Passive = suggestion  # Downgrade passive voice
+write-good.TooWordy = suggestion
+```
+
+This catches real issues without being overwhelming. Add `Google` later
+for developer-facing docs if desired.
+
+## Custom Rules
+
+Create project-specific rules in `.vale/styles/YourProject/`.
+
+### Rule Types
+
+Vale supports several rule extension points:
+
+#### substitution
+
+Flag a word and suggest a replacement.
+
+```yaml
+# .vale/styles/MyProject/Terminology.yml
+extends: substitution
+message: "Use '%s' instead of '%s'."
+level: warning
+ignorecase: true
+swap:
+  big data: large dataset
+  datasource: data source
+  e-mail: email
+  utilize: use
+  in order to: to
+  at this point in time: now
+```
+
+#### existence
+
+Flag words or patterns that should not appear.
+
+```yaml
+# .vale/styles/MyProject/Jargon.yml
+extends: existence
+message: "Avoid jargon: '%s'. Define the term or use a simpler alternative."
+level: warning
+ignorecase: true
+tokens:
+  - synergy
+  - leverage  # as a verb
+  - paradigm
+  - TODO
+  - FIXME
+  - HACK
+```
+
+#### occurrence
+
+Flag words that appear too many times.
+
+```yaml
+# .vale/styles/MyProject/Repetition.yml
+extends: occurrence
+message: "'%s' appears %d times in this section. Consider varying your language."
+level: suggestion
+scope: paragraph
+max: 3
+token: '\b(\w+)\b'
+```
+
+#### conditional
+
+Flag a word only if another word is not present.
+
+```yaml
+# .vale/styles/MyProject/AcronymDefinition.yml
+extends: conditional
+message: "Define the acronym '%s' before using it."
+level: warning
+first: '(?:API|CLI|CI|HPC|RSE|DOI)'
+second: 'Application Programming Interface|Command.Line Interface|Continuous Integration|High.Performance Computing|Research Software Engineer|Digital Object Identifier'
+```
+
+#### consistency
+
+Enforce consistent usage of one form over another.
+
+```yaml
+# .vale/styles/MyProject/Consistency.yml
+extends: consistency
+message: "Use '%s' consistently. You've used both '%s' and '%s'."
+level: error
+either:
+  dataset: data set
+  email: e-mail
+  filename: file name
+  open source: open-source  # as adjective
+```
+
+### File Structure
+
+```
+.vale/
+├── styles/
+│   ├── MyProject/
+│   │   ├── Terminology.yml
+│   │   ├── Jargon.yml
+│   │   ├── Consistency.yml
+│   │   └── AcronymDefinition.yml
+│   └── Vocab/
+│       └── MyProject/
+│           ├── accept.txt
+│           └── reject.txt
+└── .gitkeep
+```
+
+## Vocabulary
+
+Vocabulary files define project-specific terminology that Vale should accept
+or reject, regardless of style rules.
+
+### accept.txt
+
+Words that Vale should always accept (not flag as misspellings or jargon):
+
+```
+# .vale/styles/Vocab/MyProject/accept.txt
+# Domain-specific terms
+NetCDF
+HDF5
+xarray
+NumPy
+FITS
+WCS
+photometry
+spectroscopy
+
+# Project-specific terms
+MyProject
+mytool
+
+# Abbreviations
+RSE
+HPC
+CI/CD
+```
+
+### reject.txt
+
+Words that Vale should always flag:
+
+```
+# .vale/styles/Vocab/MyProject/reject.txt
+# Deprecated terms
+master branch
+whitelist
+blacklist
+sanity check
+```
+
+### Linking Vocabulary to Configuration
+
+```ini
+# .vale.ini
+Vocab = MyProject
+# This tells Vale to look in .vale/styles/Vocab/MyProject/
+```
+
+## Scoping and File Types
+
+### Supported File Types
+
+Vale natively understands these markup formats:
+
+| Format | Extension | Scope Support |
+|--------|-----------|--------------|
+| Markdown | `.md` | Headings, code blocks, links, lists |
+| reStructuredText | `.rst` | Directives, roles, code blocks |
+| AsciiDoc | `.adoc` | Blocks, macros |
+| HTML | `.html` | Tags, attributes |
+| Org | `.org` | Org-mode syntax |
+| DITA XML | `.dita` | DITA elements |
+
+### Scope Control
+
+Vale automatically skips code blocks. You can also control scoping:
+
+```ini
+# Skip specific heading levels
+[*.md]
+# Only check prose, not code
+BlockIgnores = (?s) *({{% highlight .* %}}.*?{{% /highlight %}})
+
+# Skip specific sections by pattern
+TokenIgnores = (\$[^\n$]+\$)  # Skip inline LaTeX math
+```
+
+### Inline Ignoring
+
+Disable Vale for specific lines or sections:
+
+```markdown
+<!-- vale off -->
+This text is not checked by Vale.
+<!-- vale on -->
+
+This text IS checked.
+
+<!-- vale Google.Passive = NO -->
+This sentence is allowed to be passive.
+<!-- vale Google.Passive = YES -->
+```
+
+## Integration
+
+### Editor Plugins
+
+| Editor | Plugin |
+|--------|--------|
+| VS Code | [Vale VSCode](https://marketplace.visualstudio.com/items?itemName=ChrisChinchilla.vale-vscode) |
+| Neovim | [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) or [nvim-lint](https://github.com/mfussenegger/nvim-lint) |
+| Sublime Text | [SublimeLinter-vale](https://github.com/SublimeLinter/SublimeLinter-vale) |
+| Emacs | [flycheck-vale](https://github.com/abingham/flycheck-vale) |
+
+### Pre-commit Hook
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/errata-ai/vale
+    rev: v3.9.1  # Use latest version
+    hooks:
+      - id: vale
+        args: [--config=.vale.ini]
+        # Only check documentation files:
+        files: \.(md|rst|adoc)$
+```
+
+### GitHub Actions
+
+```yaml
+name: Documentation Quality
+on:
+  pull_request:
+    paths: ['**.md', '**.rst', 'docs/**']
+
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          reporter: github-pr-review
+          # Posts inline comments on PR
+```
+
+**The `reviewdog` reporter** posts Vale findings as inline PR review comments,
+making it easy to address issues during code review.
+
+### Makefile Target
+
+```makefile
+.PHONY: lint-docs
+lint-docs:
+	vale sync
+	vale docs/ README.md CONTRIBUTING.md
+```
+
+## Configuration Recipes
+
+### Research Software Default
+
+```ini
+StylesPath = .vale/styles
+MinAlertLevel = suggestion
+Vocab = MyProject
+Packages = proselint, write-good
+
+[*.md]
+BasedOnStyles = Vale, proselint, write-good
+write-good.Passive = suggestion
+write-good.TooWordy = suggestion
+
+[docs/api/*.md]
+BasedOnStyles = Vale
+# API docs have different conventions
+```
+
+### Strict Documentation (Pre-Release)
+
+```ini
+StylesPath = .vale/styles
+MinAlertLevel = warning
+Vocab = MyProject
+Packages = proselint, write-good, Google
+
+[*.md]
+BasedOnStyles = Vale, proselint, write-good, Google
+Google.Passive = warning
+Google.We = NO  # Allow "we" in research context
+
+[CONTRIBUTING.md]
+BasedOnStyles = Vale, proselint, write-good, alex
+# Check inclusivity in contributor-facing docs
+```
+
+### Minimal (Getting Started)
+
+```ini
+StylesPath = .vale/styles
+MinAlertLevel = warning
+Packages = proselint
+
+[*.md]
+BasedOnStyles = Vale, proselint
+```
+
+## Troubleshooting
+
+### "No styles found"
+
+Run `vale sync` after adding or changing `Packages` in `.vale.ini`. Vale
+does not auto-download style packages.
+
+### Too Many False Positives
+
+1. Downgrade noisy rules: `write-good.Passive = suggestion`
+2. Add domain terms to `accept.txt` vocabulary
+3. Use inline `<!-- vale off -->` for justified exceptions
+4. Consider removing overly opinionated style packages
+
+### Vale Not Finding .vale.ini
+
+Vale searches for config in this order:
+1. `--config` flag
+2. Current directory
+3. Parent directories (walks up)
+4. Home directory
+
+Verify: `vale ls-config` shows your configuration.
+
+### Slow Performance on Large Docs
+
+- Run Vale only on changed files in CI (use `paths:` filter in GitHub Actions)
+- Exclude generated documentation directories
+- Use `MinAlertLevel = warning` to reduce output volume
+
+### Code Blocks Being Checked
+
+Vale skips fenced code blocks (` ``` `) automatically. If code is being
+checked, ensure:
+- Code blocks are properly fenced (triple backticks)
+- Indented code blocks (4 spaces) are also skipped in Markdown
+- `render` attribute in issue templates wraps input in code blocks
+
+## External Resources
+
+- [Vale Documentation](https://vale.sh/docs/) — Official docs and tutorials
+- [Vale GitHub](https://github.com/errata-ai/vale) — Source and releases
+- [Vale Studio](https://vale.sh/studio/) — Browser-based rule testing
+- [proselint](https://github.com/errata-ai/proselint) — Style package based on expert writing advice
+- [write-good](https://github.com/errata-ai/write-good) — Style package for readability
+- [Google Developer Style](https://github.com/errata-ai/Google) — Google's documentation style
+- [Microsoft Style](https://github.com/errata-ai/Microsoft) — Microsoft's writing style
+- [alex](https://github.com/errata-ai/alex) — Inclusive language checking
+- [Vale Action](https://github.com/errata-ai/vale-action) — GitHub Actions integration

--- a/plugins/project-management/skills/documentation-validation/references/VALIDATION_TOOLS.md
+++ b/plugins/project-management/skills/documentation-validation/references/VALIDATION_TOOLS.md
@@ -1,0 +1,648 @@
+# Documentation Validation Tools Reference
+
+Complete reference for all documentation validation tools: markdownlint,
+HTMLProofer, doc8, link checkers, and language-specific documentation testing.
+
+**Backlinks:** Used by the `documentation-validation` skill and the
+`documentation-validator` agent when setting up validation pipelines or
+troubleshooting tool configuration. Complements `references/VALE_CONFIGURATION.md`
+(prose linting) and `references/DOCUMENTATION_STANDARDS.md` (quality criteria).
+
+## Table of Contents
+
+| Line | Section | Description |
+|------|---------|-------------|
+| 28   | Tool Decision Matrix | Which tool for which job |
+| 55   | markdownlint | Markdown formatting and syntax validation |
+| 145  | HTMLProofer | Link checking and HTML validation for generated docs |
+| 215  | doc8 | reStructuredText linting |
+| 255  | Link Checking | Dedicated link validation tools and strategies |
+| 310  | Language-Specific Doc Testing | Doctest tools for Python, Rust, R, Go, Julia |
+| 420  | Notebook Validation | Testing Jupyter notebooks with nbval and pytest-notebook |
+| 470  | CI Pipeline Assembly | Combining tools in GitHub Actions workflows |
+| 530  | Pre-commit Integration | Adding doc validation to pre-commit hooks |
+| 565  | Makefile Targets | Standard make targets for documentation validation |
+| 590  | Performance Tips | Speeding up validation in large projects |
+| 615  | External Resources | Tool repositories and documentation links |
+
+---
+
+## Tool Decision Matrix
+
+| Need | Tool | Scope |
+|------|------|-------|
+| Markdown formatting | markdownlint | `.md` files |
+| Prose quality | Vale | `.md`, `.rst`, `.adoc` (see `references/VALE_CONFIGURATION.md`) |
+| reStructuredText syntax | doc8 | `.rst` files |
+| Broken links in HTML docs | HTMLProofer | Built HTML in `_build/` |
+| Broken links in Markdown | markdown-link-check | `.md` files |
+| Python code in docs | pytest --doctest-glob | `.md`, `.rst`, `.py` |
+| Rust code in docs | cargo test --doc | `///` doc comments |
+| R code in docs | testthat + knitr | vignettes, roxygen |
+| Go code in docs | go test | `_test.go` examples |
+| Julia code in docs | Documenter doctests | docstrings |
+| Jupyter notebooks | nbval, pytest-notebook | `.ipynb` |
+| CITATION.cff validity | cffconvert | `CITATION.cff` (see `references/CITATION_FORMAT.md`) |
+| YAML/TOML syntax | yamllint, taplo | config files |
+
+## markdownlint
+
+markdownlint validates Markdown formatting and consistency. It catches
+structural issues that prose linters like Vale miss.
+
+### Installation
+
+```bash
+# Via npm (recommended — most features)
+npm install -g markdownlint-cli2
+
+# Via Ruby gem
+gem install mdl
+
+# Via Docker
+docker run -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli2-docker:latest "**/*.md"
+```
+
+### Configuration
+
+Create `.markdownlint.yaml` (or `.markdownlint-cli2.yaml`) in the project root:
+
+```yaml
+# .markdownlint.yaml
+# See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+# Disable rules
+MD013: false            # Line length (often impractical for docs)
+MD033: false            # Inline HTML (needed for badges, details tags)
+MD041: false            # First line should be heading (not for all files)
+
+# Configure rules
+MD007:                  # Unordered list indentation
+  indent: 2
+MD024:                  # Multiple headings with same content
+  siblings_only: true   # Allow same heading in different sections
+MD029:                  # Ordered list prefix
+  style: "ordered"      # 1. 2. 3. (not 1. 1. 1.)
+```
+
+### Key Rules
+
+| Rule | Description | Default |
+|------|-------------|---------|
+| MD001 | Heading level increment (no skipping h2 → h4) | error |
+| MD003 | Heading style consistency (ATX vs setext) | error |
+| MD007 | Unordered list indentation | warning |
+| MD009 | Trailing spaces | error |
+| MD012 | Multiple consecutive blank lines | error |
+| MD013 | Line length | warning (often disabled) |
+| MD022 | Headings should be surrounded by blank lines | error |
+| MD024 | Multiple headings with same content | warning |
+| MD025 | Multiple top-level headings | error |
+| MD031 | Fenced code blocks surrounded by blank lines | error |
+| MD032 | Lists surrounded by blank lines | error |
+| MD033 | Inline HTML | warning (often disabled) |
+| MD034 | Bare URLs | warning |
+| MD040 | Fenced code blocks should have a language | warning |
+| MD041 | First line should be a top-level heading | warning |
+
+### Running markdownlint
+
+```bash
+# Check all Markdown files
+markdownlint-cli2 "**/*.md"
+
+# Check specific files
+markdownlint-cli2 README.md CONTRIBUTING.md "docs/**/*.md"
+
+# Fix auto-fixable issues
+markdownlint-cli2 --fix "**/*.md"
+
+# Ignore specific files
+markdownlint-cli2 --config .markdownlint.yaml "#node_modules" "**/*.md"
+```
+
+### Inline Disabling
+
+```markdown
+<!-- markdownlint-disable MD013 -->
+This very long line is allowed because we disabled the line length rule.
+<!-- markdownlint-enable MD013 -->
+
+<!-- markdownlint-disable-next-line MD033 -->
+<details><summary>Click to expand</summary>
+Content here
+</details>
+```
+
+## HTMLProofer
+
+HTMLProofer validates links, images, and HTML structure in built
+documentation. It works on the HTML output of documentation generators
+(Sphinx, MkDocs, Jekyll, etc.).
+
+### Installation
+
+```bash
+# Ruby gem
+gem install html-proofer
+
+# Docker
+docker run -v $PWD/_build/html:/site ghcr.io/gjtorikian/html-proofer /site
+```
+
+### Running HTMLProofer
+
+```bash
+# Check built HTML docs
+htmlproofer _build/html/ \
+  --ignore-urls "/localhost/,/127.0.0.1/" \
+  --ignore-status-codes "403,429" \
+  --allow-hash-href \
+  --check-external-hash
+
+# Common options
+htmlproofer _build/html/ \
+  --ignore-urls "/doi.org/"        # DOI links sometimes reject crawlers \
+  --no-enforce-https               # Don't require HTTPS for all links \
+  --swap-urls "^/project/:/"       # Fix base URL issues
+```
+
+### Configuration
+
+```ruby
+# Rakefile or Ruby script for more control
+HTMLProofer.check_directory('./_build/html', {
+  assume_extension: '.html',
+  check_external_hash: true,
+  check_favicon: false,
+  check_opengraph: false,
+  ignore_urls: [
+    /localhost/,
+    /doi\.org/,         # DOI links rate-limit aggressively
+    /example\.com/,     # Placeholder URLs in templates
+  ],
+  ignore_status_codes: [403, 429],
+  typhoeus: {
+    ssl_verifypeer: false,  # For self-signed certs in CI
+    timeout: 30,
+  },
+}).run
+```
+
+### What HTMLProofer Checks
+
+| Check | Description |
+|-------|-------------|
+| Links | Broken internal and external links |
+| Images | Missing image files, empty alt text |
+| Scripts | Missing script files |
+| HTML validity | Basic HTML structure issues |
+| Hash fragments | Anchor links (#section) resolve to actual IDs |
+
+### Rate Limiting and External Links
+
+External link checking can be slow and flaky. Strategies:
+
+1. **Cache results:** HTMLProofer has a built-in cache:
+   ```bash
+   htmlproofer _build/html/ --cache '{"timeframe": {"external": "1w"}}'
+   ```
+
+2. **Separate internal and external checks:**
+   - Internal links: Check on every PR (fast, reliable)
+   - External links: Check weekly in scheduled CI (slow, flaky)
+
+3. **Ignore known-flaky URLs:**
+   ```bash
+   --ignore-urls "/doi.org/,/arxiv.org/"
+   ```
+
+## doc8
+
+doc8 validates reStructuredText files for syntax and style issues.
+
+### Installation
+
+```bash
+pip install doc8
+```
+
+### Configuration
+
+```ini
+# setup.cfg or .doc8.ini
+[doc8]
+max-line-length = 99
+ignore-path = docs/_build,docs/generated
+ignore-path-errors = docs/release-notes.rst;D001
+```
+
+### Running doc8
+
+```bash
+# Check all RST files in docs/
+doc8 docs/
+
+# With custom config
+doc8 --config .doc8.ini docs/
+
+# Ignore specific errors
+doc8 --ignore D001 docs/  # D001 = line too long
+```
+
+### doc8 Error Codes
+
+| Code | Description |
+|------|-------------|
+| D000 | Invalid RST syntax |
+| D001 | Line too long |
+| D002 | Trailing whitespace |
+| D003 | Tab character found |
+| D004 | No newline at end of file |
+| D005 | No newline at end of section |
+
+## Link Checking
+
+### markdown-link-check
+
+Checks links directly in Markdown files (no HTML build required).
+
+```bash
+# Install
+npm install -g markdown-link-check
+
+# Check a file
+markdown-link-check README.md
+
+# Check all Markdown files
+find . -name '*.md' -exec markdown-link-check {} \;
+```
+
+Configuration (`.markdown-link-check.json`):
+
+```json
+{
+  "ignorePatterns": [
+    { "pattern": "^https://example\\.com" },
+    { "pattern": "^#" }
+  ],
+  "replacementPatterns": [
+    { "pattern": "^/docs/", "replacement": "https://project.readthedocs.io/en/latest/" }
+  ],
+  "httpHeaders": [
+    { "urls": ["https://github.com"], "headers": { "Accept": "text/html" } }
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 3
+}
+```
+
+### lychee
+
+Fast link checker written in Rust. Handles large documentation sets well.
+
+```bash
+# Install
+cargo install lychee
+# or
+brew install lychee
+
+# Check all docs
+lychee "**/*.md" "**/*.rst" --exclude "example\\.com"
+
+# Check with GitHub token (avoids rate limiting)
+GITHUB_TOKEN=xxx lychee "**/*.md"
+```
+
+## Language-Specific Doc Testing
+
+### Python: pytest doctest
+
+Test code examples embedded in documentation:
+
+```bash
+# Test code blocks in Markdown files
+pytest --doctest-glob="*.md" docs/
+
+# Test code blocks in RST files
+pytest --doctest-glob="*.rst" docs/
+
+# Test docstrings in Python source
+pytest --doctest-modules src/
+```
+
+**Configuration (pyproject.toml):**
+```toml
+[tool.pytest.ini_options]
+addopts = "--doctest-glob='*.md' --doctest-glob='*.rst'"
+doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+```
+
+**Requirements:**
+- Code blocks must start with `>>>` (Python doctest format)
+- Expected output follows the `>>>` line
+- Use `...` for continuation lines
+- Use `# doctest: +SKIP` to skip untestable examples
+
+### Rust: cargo test --doc
+
+Rust tests all code examples in doc comments by default:
+
+```bash
+# Test all documentation examples
+cargo test --doc
+
+# Test docs for a specific module
+cargo test --doc -- module_name
+```
+
+**How it works:** Every fenced code block in `///` doc comments is compiled
+and run. Blocks marked with `no_run` are compiled but not executed. Blocks
+marked with `ignore` are skipped entirely.
+
+```rust
+/// Adds two numbers.
+///
+/// # Examples
+///
+/// ```
+/// let result = mylib::add(2, 3);
+/// assert_eq!(result, 5);
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+### R: testthat + knitr
+
+```r
+# Run examples in roxygen documentation
+devtools::run_examples()
+
+# Test vignettes (Rmd files)
+devtools::test()  # Runs testthat tests
+devtools::build_vignettes()  # Builds and tests Rmd vignettes
+```
+
+**R-specific tools:**
+- `roxygen2`: Generates documentation from comments
+- `pkgdown`: Builds documentation websites
+- `spelling::spell_check_package()`: Spell checks documentation
+- `urlchecker::url_check()`: Checks URLs in package documentation
+
+### Go: testable examples
+
+Go has a built-in convention for testable examples in `_test.go` files:
+
+```go
+func ExampleAdd() {
+    result := Add(2, 3)
+    fmt.Println(result)
+    // Output: 5
+}
+```
+
+```bash
+# Run all tests including examples
+go test ./...
+
+# Run only example tests
+go test -run Example ./...
+```
+
+### Julia: Documenter doctests
+
+Julia's `Documenter.jl` tests code blocks in docstrings:
+
+```julia
+"""
+    add(a, b)
+
+Add two numbers.
+
+# Examples
+```jldoctest
+julia> add(2, 3)
+5
+```
+"""
+function add(a, b)
+    return a + b
+end
+```
+
+```bash
+# Run doctests via Documenter
+julia --project=docs -e 'using Documenter; doctest(MyPackage)'
+```
+
+## Notebook Validation
+
+### nbval
+
+Tests that Jupyter notebook outputs match saved outputs:
+
+```bash
+pip install nbval
+
+# Validate all notebooks
+pytest --nbval docs/notebooks/
+
+# Validate but allow output changes (just check execution succeeds)
+pytest --nbval-lax docs/notebooks/
+
+# Skip specific cells
+# Add metadata to cell: {"tags": ["nbval-skip"]}
+```
+
+### pytest-notebook
+
+More flexible notebook testing with configurable comparison:
+
+```bash
+pip install pytest-notebook
+
+# Run notebook tests
+pytest --nb-test-files docs/notebooks/
+```
+
+**Configuration (pyproject.toml):**
+```toml
+[tool.pytest.ini_options]
+nb_test_files = "docs/notebooks/*.ipynb"
+nb_diff_ignore = ["/cells/*/outputs/*/text", "/metadata"]
+```
+
+### Notebook-Specific Considerations
+
+- **Execution time:** Notebooks with expensive computations need timeout configuration
+- **Data dependencies:** Notebooks may need test data — ensure it's available in CI
+- **Environment consistency:** Pin notebook kernel to match CI environment
+- **Output stability:** Floating-point outputs and timestamps change between runs — use `--nbval-lax` or configure tolerances
+
+## CI Pipeline Assembly
+
+### Complete Documentation CI Workflow
+
+```yaml
+name: Documentation Quality
+on:
+  pull_request:
+    paths: ['**.md', '**.rst', 'docs/**', '.vale.ini', '.markdownlint.yaml']
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: "**/*.md"
+
+  prose-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          reporter: github-pr-review
+
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: "--exclude example\\.com '**/*.md'"
+
+  # Run separately on a schedule for external links:
+  external-links:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: "'**/*.md' '**/*.rst'"
+```
+
+### Adding Doc Testing to Existing CI
+
+```yaml
+# Add to an existing test job
+- name: Test documentation examples
+  run: |
+    # Python
+    pytest --doctest-glob="*.md" --doctest-glob="*.rst" docs/
+
+    # Or Rust
+    cargo test --doc
+
+    # Or Go
+    go test -run Example ./...
+```
+
+## Pre-commit Integration
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  # Markdown formatting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.43.0
+    hooks:
+      - id: markdownlint
+        args: ["--config", ".markdownlint.yaml"]
+
+  # Prose quality (Vale)
+  - repo: https://github.com/errata-ai/vale
+    rev: v3.9.1
+    hooks:
+      - id: vale
+        args: ["--config", ".vale.ini"]
+        files: \.(md|rst)$
+
+  # Link checking (fast, internal only)
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.2
+    hooks:
+      - id: markdown-link-check
+        args: ["--config", ".markdown-link-check.json"]
+
+  # YAML validation (for issue templates, CI workflows)
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: ["-c", ".yamllint.yaml"]
+```
+
+## Makefile Targets
+
+```makefile
+.PHONY: lint-docs check-links test-docs validate-docs
+
+# Individual targets
+lint-docs:
+	vale sync && vale docs/ README.md CONTRIBUTING.md
+	markdownlint-cli2 "**/*.md"
+
+check-links:
+	lychee --exclude "example\.com" "**/*.md"
+
+test-docs:
+	pytest --doctest-glob="*.md" docs/
+
+# Combined target
+validate-docs: lint-docs check-links test-docs
+	@echo "All documentation validation passed"
+```
+
+## Performance Tips
+
+### Large Documentation Sets
+
+1. **Parallelize in CI:** Run Vale, markdownlint, and link checks as
+   separate CI jobs (they're independent).
+
+2. **Check only changed files in PRs:**
+   ```bash
+   git diff --name-only HEAD~1 -- '*.md' | xargs vale
+   ```
+
+3. **Cache external link results:** HTMLProofer and lychee both support caching.
+
+4. **Separate internal and external link checks:** Internal links are fast
+   and reliable — check on every PR. External links are slow and flaky —
+   check on a schedule.
+
+5. **Skip generated files:** Exclude `_build/`, `generated/`, `node_modules/`
+   from validation.
+
+### CI Time Budget
+
+| Tool | Typical Time | Notes |
+|------|-------------|-------|
+| markdownlint | 2-5 seconds | Very fast |
+| Vale | 5-15 seconds | Depends on style package count |
+| lychee (internal) | 5-10 seconds | Fast for internal links |
+| lychee (external) | 30-120 seconds | Network-bound, flaky |
+| HTMLProofer | 10-60 seconds | Depends on doc size and external links |
+| pytest doctest | Varies | Depends on example complexity |
+
+## External Resources
+
+- [markdownlint Rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md) — Complete rule reference
+- [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) — CLI tool
+- [HTMLProofer](https://github.com/gjtorikian/html-proofer) — HTML validation tool
+- [doc8](https://github.com/PyCQA/doc8) — RST linting
+- [lychee](https://github.com/lycheeverse/lychee) — Fast link checker
+- [markdown-link-check](https://github.com/tcort/markdown-link-check) — Markdown link checker
+- [nbval](https://github.com/computationalmodelling/nbval) — Notebook validation
+- [pytest-notebook](https://github.com/chrisjsewell/pytest-notebook) — Notebook testing
+- [yamllint](https://github.com/adrienverge/yamllint) — YAML linting
+- [taplo](https://github.com/tamasfe/taplo) — TOML formatting and validation
+- [Vale Documentation](https://vale.sh/docs/) — See also `references/VALE_CONFIGURATION.md`
+- [Diataxis Framework](https://diataxis.fr/) — See also `references/DOCUMENTATION_STANDARDS.md`


### PR DESCRIPTION
## Summary

- Adds the refocused `project-management` plugin covering project lifecycle concerns: onboarding, documentation quality, handoff readiness, and community health files
- Refactored from the previous monolithic plugin per #60 — GitHub platform mechanics and containerization are scoped for separate plugins (#58, #59)
- All content is language-agnostic (Python, Rust, Go, R, Julia, Node.js, C/C++)
- Frontmatter follows agentskills.io best practices

### Plugin contents

| Type | Name |
|------|------|
| Agent | `project-onboarding-specialist` — project initialization, contributor onboarding, knowledge transfer |
| Agent | `documentation-validator` — documentation QA, setup instruction validation, completeness checking |
| Skill | `community-health-files` — templates for README, CONTRIBUTING, LICENSE, CODE_OF_CONDUCT, SECURITY, CITATION.cff (5 asset templates, 3 reference guides) |
| Skill | `documentation-validation` — Vale, markdownlint, HTMLProofer, doc testing, CI integration (2 asset configs, 3 reference guides) |
| Command | `/setup-project` — scaffold a new project with community health files |
| Command | `/project-handoff` — assess project readiness for handoff |
| Command | `/validate-project-handoff` — test that setup instructions actually work |

### Other changes

- Updated repo-level `README.md` with plugin description and tree structure
- Added plugin entry to `marketplace.json`

Closes #60

## Test plan

- [ ] Verify plugin loads correctly in Claude Code: `/plugin install ./plugins/project-management`
- [ ] Test `/setup-project` scaffolds files correctly for multiple languages
- [ ] Test `/project-handoff` generates a valid readiness report
- [ ] Test `/validate-project-handoff` traces through setup instructions
- [ ] Verify agents resolve their declared skills (`community-health-files`, `documentation-validation`)
- [ ] Confirm reference file TOCs have accurate line numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)