### PR TITLE
fix(holoviz-visualization): use ${HOME} for portable MCP volume mount

### DIFF
--- a/community-plugins/holoviz-visualization/.mcp.json
+++ b/community-plugins/holoviz-visualization/.mcp.json
@@ -7,7 +7,7 @@
         "-i",
         "--rm",
         "-v",
-        "~/.holoviz-mcp:/root/.holoviz-mcp",
+        "${HOME}/.holoviz-mcp:/root/.holoviz-mcp",
         "ghcr.io/marcskovmadsen/holoviz-mcp:latest"
       ],
       "env": {}


### PR DESCRIPTION
## Summary

Fixes a portability bug in `community-plugins/holoviz-visualization/.mcp.json`: the docker volume mount uses `~/.holoviz-mcp` which Docker treats as a literal directory name rather than the user's home (the `~` only expands in shell, not in JSON args passed directly to docker).

Result on the affected setup: the MCP server can't reach the user's `~/.holoviz-mcp` data dir, so any persistent state (snippets etc.) isn't visible inside the container.

## Fix

Replace `~/.holoviz-mcp` with `${HOME}/.holoviz-mcp`. Claude Code's MCP config loader expands `${HOME}` (and `${env:VAR}` style variables) before invoking the command, so on macOS the args become `/Users/<me>/.holoviz-mcp:/root/.holoviz-mcp` and on Linux `/home/<them>/.holoviz-mcp:/...`. No host-specific path checked into git; works for every contributor.

Reference: <https://code.claude.com/docs/en/mcp-servers.md#environment-variable-expansion-in-mcp-json>

## Diff

```diff
-        "~/.holoviz-mcp:/root/.holoviz-mcp",
+        "${HOME}/.holoviz-mcp:/root/.holoviz-mcp",
```

## Test plan

- [ ] CI: `validate` (Validate Plugins) passes — the `.mcp.json` still parses as valid JSON.
- [ ] Manual: with the holoviz-visualization plugin installed, restart Claude Code and run a `holoviz-mcp/*` tool call. The container should now see the user's `~/.holoviz-mcp` directory rather than an empty docker-managed volume.
- [ ] Manual on Linux: confirm `${HOME}` resolves to the user's home (not root's home, even when running rootful docker).

## Unresolved risks

- If a contributor has rootful docker configured to run containers as root, `${HOME}` will still expand to the invoking user's home — this is the desired behavior for this MCP, where state lives in the user's home, not root's. Behavior unchanged from the original `~` intent.