### PR TITLE
feat(devcontainer): add Copilot CLI with RSE plugins and optional LiteLLM gateway

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "RSE Agents Plugin Demo",
+  "name": "RSE Plugins Demo",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
@@ -12,13 +12,27 @@
         "GitHub.copilot",
         "GitHub.copilot-chat",
         "johnny-zhao.oai-compatible-copilot",
-        "anthropics.claude-code"
+        "anthropics.claude-code",
+        "ms-python.python"
       ],
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash"
       }
     }
   },
+  "secrets": {
+    "LITELLM_BASE_URL": {
+      "description": "Optional: Base URL for a LiteLLM-compatible gateway (e.g. https://your-gateway.example.com). If set along with LITELLM_API_KEY, Copilot will route through this gateway."
+    },
+    "LITELLM_API_KEY": {
+      "description": "Optional: API key for the LiteLLM-compatible gateway."
+    }
+  },
+  "remoteEnv": {
+    "OAI_API_KEY": "${localEnv:LITELLM_API_KEY}"
+  },
   "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postStartCommand": "bash .devcontainer/post-start.sh",
+  "postAttachCommand": "bash .devcontainer/install-vsix.sh",
   "remoteUser": "vscode"
 }

--- a/.devcontainer/install-vsix.sh
+++ b/.devcontainer/install-vsix.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Post-attach script for GitHub Codespaces
+# Installs OAI-compatible Copilot VSIX and configures VS Code gateway settings
+# if LiteLLM credentials are present. Non-fatal on failure.
+
+set -uo pipefail
+
+VSIX_ENV=".devcontainer/oai-compatible-copilot-vsix.env"
+VSIX_CACHE_DIR="${HOME}/.cache/oai-compatible-copilot"
+MACHINE_SETTINGS_DIR="${HOME}/.vscode-server/data/Machine"
+MACHINE_SETTINGS="${MACHINE_SETTINGS_DIR}/settings.json"
+
+# Guard: skip if LiteLLM gateway is not configured
+if [ -z "${LITELLM_BASE_URL:-}" ]; then
+    exit 0
+fi
+
+echo "[install-vsix] LiteLLM gateway detected. Installing OAI-compatible Copilot extension..."
+
+# Load pinned VSIX metadata
+if [ ! -f "${VSIX_ENV}" ]; then
+    echo "[install-vsix] WARNING: ${VSIX_ENV} not found. Skipping VSIX install."
+    exit 0
+fi
+
+# shellcheck source=/dev/null
+source "${VSIX_ENV}"
+
+# Validate required variables
+if [ -z "${VSIX_FILENAME:-}" ] || [ -z "${EXPECTED_VSIX_SHA256:-}" ]; then
+    echo "[install-vsix] WARNING: Missing required variables in ${VSIX_ENV}. Skipping."
+    exit 0
+fi
+
+VSIX_PATH="${VSIX_CACHE_DIR}/${VSIX_FILENAME}"
+
+# Validate VSIX filename contains no path traversal characters
+if echo "${VSIX_FILENAME}" | grep -qE '(\.\.|/)'; then
+    echo "[install-vsix] WARNING: VSIX_FILENAME contains unsafe path characters. Skipping."
+    exit 0
+fi
+
+# Verify cached VSIX exists and matches expected SHA256
+if [ ! -f "${VSIX_PATH}" ]; then
+    echo "[install-vsix] WARNING: VSIX not found in cache (${VSIX_PATH}). Run rebuild to re-download."
+    exit 0
+fi
+
+ACTUAL_SHA256="$(sha256sum "${VSIX_PATH}" | awk '{print $1}')"
+if [ "${ACTUAL_SHA256}" != "${EXPECTED_VSIX_SHA256}" ]; then
+    echo "[install-vsix] WARNING: VSIX SHA256 mismatch. Skipping installation."
+    exit 0
+fi
+
+# Find VS Code CLI binary
+CODE_BIN=""
+for candidate in \
+    "/vscode/vscode-server/bin/linux-x64/*/bin/remote-cli/code" \
+    "${HOME}/.vscode-server/bin/*/bin/remote-cli/code" \
+    "/usr/local/bin/code"; do
+    # shellcheck disable=SC2086
+    match="$(ls ${candidate} 2>/dev/null | head -1 || true)"
+    if [ -n "${match}" ] && [ -x "${match}" ]; then
+        CODE_BIN="${match}"
+        break
+    fi
+done
+
+if [ -z "${CODE_BIN}" ]; then
+    echo "[install-vsix] WARNING: VS Code CLI not found. Skipping VSIX installation."
+    exit 0
+fi
+
+# Install VSIX if not already installed
+EXTENSION_ID="johnny-zhao.oai-compatible-copilot"
+if "${CODE_BIN}" --list-extensions 2>/dev/null | grep -qi "${EXTENSION_ID}"; then
+    echo "[install-vsix] OAI-compatible Copilot extension already installed."
+else
+    echo "[install-vsix] Installing VSIX..."
+    if ! "${CODE_BIN}" --install-extension "${VSIX_PATH}" --force 2>/dev/null; then
+        echo "[install-vsix] WARNING: VSIX install failed. Default Copilot will be used."
+        exit 0
+    fi
+    echo "[install-vsix] VSIX installed successfully."
+fi
+
+# Write machine-level VS Code settings to route Copilot Chat through the gateway
+mkdir -p "${MACHINE_SETTINGS_DIR}"
+
+# Merge or create settings.json
+if [ -f "${MACHINE_SETTINGS}" ]; then
+    # Use python3 to merge settings (available via the python devcontainer feature)
+    python3 - <<PYEOF
+import json, sys
+
+path = "${MACHINE_SETTINGS}"
+try:
+    with open(path, "r") as f:
+        settings = json.load(f)
+except (json.JSONDecodeError, FileNotFoundError):
+    settings = {}
+
+settings["oai-compatible-copilot.baseUrl"] = "${LITELLM_BASE_URL}/v1"
+settings["oai-compatible-copilot.models"] = [
+    {"name": "gpt-5.4-mini", "isDefault": True},
+    {"name": "gpt-oss-120b"}
+]
+
+with open(path, "w") as f:
+    json.dump(settings, f, indent=2)
+    f.write("\n")
+
+print("[install-vsix] VS Code gateway settings written.")
+PYEOF
+else
+    cat > "${MACHINE_SETTINGS}" <<JSON
+{
+  "oai-compatible-copilot.baseUrl": "${LITELLM_BASE_URL}/v1",
+  "oai-compatible-copilot.models": [
+    {"name": "gpt-5.4-mini", "isDefault": true},
+    {"name": "gpt-oss-120b"}
+  ]
+}
+JSON
+    echo "[install-vsix] VS Code gateway settings written."
+fi
+
+echo "[install-vsix] Copilot Chat will use the LiteLLM gateway models."

--- a/.devcontainer/oai-compatible-copilot-vsix.env
+++ b/.devcontainer/oai-compatible-copilot-vsix.env
@@ -1,0 +1,9 @@
+# Pinned release metadata for the OAI-compatible Copilot VS Code extension.
+# This file is a reviewed trust anchor — update only via reviewed pull requests.
+# The SHA256 is committed here (not downloaded alongside the artifact) to prevent
+# simultaneous replacement of both the binary and its verification hash.
+
+VSIX_RELEASE_TAG=sandbox-latest
+VSIX_FILENAME=oai-compatible-copilot-sandbox.vsix
+VSIX_SOURCE_COMMIT=579762a
+EXPECTED_VSIX_SHA256=19008cc783d474d9961658b23c78d0113dbdebb4dd35ee0bc8a4e1dee28093d1

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -122,7 +122,7 @@ else
             fi
 
             if [ "${NEEDS_DOWNLOAD}" = "true" ]; then
-                DOWNLOAD_URL="https://github.com/uw-ssec/rse-plugins/releases/download/${VSIX_RELEASE_TAG}/${VSIX_FILENAME}"
+                DOWNLOAD_URL="https://github.com/uw-ssec/oai-compatible-copilot/releases/download/${VSIX_RELEASE_TAG}/${VSIX_FILENAME}"
                 log "Downloading VSIX from ${DOWNLOAD_URL}..."
 
                 DOWNLOAD_OK=true

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,71 +1,157 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Post-create script for GitHub Codespaces
-# Installs Claude Code and copies plugin agents/skills to .github directory
+# Installs Claude Code, Copilot CLI with RSE plugins, and sets up .github/ directory
 
-set -e
+set -euo pipefail
 
-echo "=== Setting up RSE Agents Codespace ==="
+log() { echo "[post-create] $*"; }
 
-# Install Claude Code CLI globally
-echo "Installing Claude Code CLI..."
+echo ""
+echo "=== Setting up RSE Plugins Codespace ==="
+echo ""
+
+# --- Install Claude Code CLI ---
+log "Installing Claude Code CLI..."
 curl -fsSL https://claude.ai/install.sh | bash
 
-# Create .github/agents and .github/skills directories
-echo "Creating .github/agents and .github/skills directories..."
+# --- Install GitHub Copilot CLI ---
+log "Installing GitHub Copilot CLI..."
+if ! command -v copilot &>/dev/null; then
+    curl -fsSL https://gh.io/copilot-install | bash
+else
+    log "Copilot CLI already installed, skipping."
+fi
+
+# Verify copilot is available
+if ! command -v copilot &>/dev/null; then
+    log "ERROR: Copilot CLI not found after install. Aborting."
+    exit 1
+fi
+
+# --- Register RSE plugins marketplace ---
+log "Registering uw-ssec/rse-plugins marketplace..."
+copilot marketplace add uw-ssec/rse-plugins
+
+# --- Install all RSE plugins ---
+log "Installing RSE plugins..."
+PLUGINS=(
+    "ai-research-workflows@rse-plugins"
+    "scientific-python-development@rse-plugins"
+    "project-management@rse-plugins"
+    "scientific-domain-applications@rse-plugins"
+    "holoviz-visualization@rse-plugins"
+    "gaia-data-downloader@rse-plugins"
+    "zarr-chunk-optimization@rse-plugins"
+    "zarr-data-format@rse-plugins"
+    "research-software-design@rse-plugins"
+)
+
+for plugin in "${PLUGINS[@]}"; do
+    log "  Installing ${plugin}..."
+    copilot install "${plugin}"
+done
+
+# --- Copy agents and skills to .github/ for workspace discovery ---
+log "Copying agents and skills to .github/..."
 mkdir -p .github/agents
 mkdir -p .github/skills
 
-# Copy agents from plugins directory
-echo "Copying agents from plugins..."
-if [ -d "plugins" ]; then
-    for plugin_dir in plugins/*/; do
-        if [ -d "${plugin_dir}agents" ]; then
-            cp -r "${plugin_dir}agents"/* .github/agents/ 2>/dev/null || true
-            echo "  - Copied agents from ${plugin_dir}"
+for plugin_dir in plugins/*/; do
+    if [ -d "${plugin_dir}agents" ]; then
+        cp -r "${plugin_dir}agents"/* .github/agents/ 2>/dev/null || true
+    fi
+done
+
+for plugin_dir in community-plugins/*/; do
+    if [ -d "${plugin_dir}agents" ]; then
+        cp -r "${plugin_dir}agents"/* .github/agents/ 2>/dev/null || true
+    fi
+done
+
+for plugin_dir in plugins/*/; do
+    if [ -d "${plugin_dir}skills" ]; then
+        cp -r "${plugin_dir}skills"/* .github/skills/ 2>/dev/null || true
+    fi
+done
+
+for plugin_dir in community-plugins/*/; do
+    if [ -d "${plugin_dir}skills" ]; then
+        cp -r "${plugin_dir}skills"/* .github/skills/ 2>/dev/null || true
+    fi
+done
+
+# --- Conditionally download OAI-compatible Copilot VSIX ---
+VSIX_ENV=".devcontainer/oai-compatible-copilot-vsix.env"
+VSIX_CACHE_DIR="${HOME}/.cache/oai-compatible-copilot"
+
+if [ -z "${LITELLM_BASE_URL:-}" ]; then
+    log "No LITELLM_BASE_URL set. Skipping OAI-compatible Copilot VSIX download."
+    log "To use a LiteLLM gateway, set LITELLM_BASE_URL and LITELLM_API_KEY as Codespace secrets and rebuild."
+else
+    log "LiteLLM gateway detected. Downloading OAI-compatible Copilot VSIX..."
+
+    if [ ! -f "${VSIX_ENV}" ]; then
+        log "WARNING: ${VSIX_ENV} not found. Skipping VSIX download."
+    else
+        # Load pinned VSIX metadata
+        # shellcheck source=/dev/null
+        source "${VSIX_ENV}"
+
+        # Validate required variables
+        if [ -z "${VSIX_RELEASE_TAG:-}" ] || [ -z "${VSIX_FILENAME:-}" ] || [ -z "${EXPECTED_VSIX_SHA256:-}" ]; then
+            log "WARNING: Missing required variables in ${VSIX_ENV}. Skipping VSIX download."
+        elif ! echo "${EXPECTED_VSIX_SHA256}" | grep -qE '^[0-9a-f]{64}$'; then
+            log "WARNING: EXPECTED_VSIX_SHA256 is not a valid 64-character hex SHA256. Skipping."
+        elif echo "${VSIX_FILENAME}" | grep -qE '(\.\.|/)'; then
+            log "WARNING: VSIX_FILENAME contains unsafe path characters. Skipping."
+        else
+            mkdir -p "${VSIX_CACHE_DIR}"
+            VSIX_PATH="${VSIX_CACHE_DIR}/${VSIX_FILENAME}"
+
+            # Re-download if missing or hash mismatch
+            NEEDS_DOWNLOAD=true
+            if [ -f "${VSIX_PATH}" ]; then
+                ACTUAL_SHA256="$(sha256sum "${VSIX_PATH}" | awk '{print $1}')"
+                if [ "${ACTUAL_SHA256}" = "${EXPECTED_VSIX_SHA256}" ]; then
+                    log "Cached VSIX is valid. Skipping download."
+                    NEEDS_DOWNLOAD=false
+                else
+                    log "Cached VSIX SHA256 mismatch. Re-downloading..."
+                    rm -f "${VSIX_PATH}"
+                fi
+            fi
+
+            if [ "${NEEDS_DOWNLOAD}" = "true" ]; then
+                DOWNLOAD_URL="https://github.com/uw-ssec/rse-plugins/releases/download/${VSIX_RELEASE_TAG}/${VSIX_FILENAME}"
+                log "Downloading VSIX from ${DOWNLOAD_URL}..."
+
+                DOWNLOAD_OK=true
+                curl -fsSL --tlsv1.2 --retry 3 --retry-delay 2 \
+                    -o "${VSIX_PATH}" "${DOWNLOAD_URL}" || DOWNLOAD_OK=false
+
+                if [ "${DOWNLOAD_OK}" = "true" ]; then
+                    ACTUAL_SHA256="$(sha256sum "${VSIX_PATH}" | awk '{print $1}')"
+                    if [ "${ACTUAL_SHA256}" != "${EXPECTED_VSIX_SHA256}" ]; then
+                        log "WARNING: Downloaded VSIX SHA256 mismatch. Removing."
+                        rm -f "${VSIX_PATH}"
+                    else
+                        log "VSIX downloaded and verified successfully."
+                    fi
+                else
+                    log "WARNING: VSIX download failed. Default Copilot models will be used."
+                    rm -f "${VSIX_PATH}"
+                fi
+            fi
         fi
-    done
+    fi
 fi
 
-# Copy agents from community-plugins directory
-echo "Copying agents from community-plugins..."
-if [ -d "community-plugins" ]; then
-    for plugin_dir in community-plugins/*/; do
-        if [ -d "${plugin_dir}agents" ]; then
-            cp -r "${plugin_dir}agents"/* .github/agents/ 2>/dev/null || true
-            echo "  - Copied agents from ${plugin_dir}"
-        fi
-    done
-fi
-
-# Copy skills from plugins directory
-echo "Copying skills from plugins..."
-if [ -d "plugins" ]; then
-    for plugin_dir in plugins/*/; do
-        if [ -d "${plugin_dir}skills" ]; then
-            cp -r "${plugin_dir}skills"/* .github/skills/ 2>/dev/null || true
-            echo "  - Copied skills from ${plugin_dir}"
-        fi
-    done
-fi
-
-# Copy skills from community-plugins directory
-echo "Copying skills from community-plugins..."
-if [ -d "community-plugins" ]; then
-    for plugin_dir in community-plugins/*/; do
-        if [ -d "${plugin_dir}skills" ]; then
-            cp -r "${plugin_dir}skills"/* .github/skills/ 2>/dev/null || true
-            echo "  - Copied skills from ${plugin_dir}"
-        fi
-    done
-fi
-
-# Summary
+# --- Summary ---
 echo ""
 echo "=== Setup Complete ==="
-echo "Agents copied to .github/agents:"
-ls -1 .github/agents/ 2>/dev/null || echo "  (none)"
 echo ""
-echo "Skills copied to .github/skills:"
-ls -1 .github/skills/ 2>/dev/null || echo "  (none)"
+echo "Agents in .github/agents: $(ls -1 .github/agents/ 2>/dev/null | wc -l | tr -d ' ')"
+echo "Skills in .github/skills: $(ls -1 .github/skills/ 2>/dev/null | wc -l | tr -d ' ')"
 echo ""
-echo "Claude Code is ready to use!"
+echo "Claude Code and GitHub Copilot CLI are ready to use."
+echo "Run 'copilot' in the terminal to get started."

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -30,7 +30,7 @@ fi
 
 # --- Register RSE plugins marketplace ---
 log "Registering uw-ssec/rse-plugins marketplace..."
-copilot marketplace add uw-ssec/rse-plugins
+copilot plugin marketplace add uw-ssec/rse-plugins
 
 # --- Install all RSE plugins ---
 log "Installing RSE plugins..."
@@ -48,7 +48,7 @@ PLUGINS=(
 
 for plugin in "${PLUGINS[@]}"; do
     log "  Installing ${plugin}..."
-    copilot install "${plugin}"
+    copilot plugin install "${plugin}"
 done
 
 # --- Copy agents and skills to .github/ for workspace discovery ---

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Post-start script for GitHub Codespaces
+# Configures Copilot CLI to route through LiteLLM gateway if credentials are present
+
+set -euo pipefail
+
+echo ""
+echo "=== RSE Plugins Codespace ==="
+echo ""
+
+BASHRC="${HOME}/.bashrc"
+GATEWAY_MARKER='# >>> litellm-gateway-env (rse-plugins) >>>'
+
+if [ -n "${LITELLM_BASE_URL:-}" ] && [ -n "${LITELLM_API_KEY:-}" ]; then
+    echo "[post-start] LiteLLM gateway detected. Configuring Copilot CLI environment..."
+
+    # Write gateway env vars to ~/.bashrc idempotently
+    if ! grep -qF "${GATEWAY_MARKER}" "${BASHRC}" 2>/dev/null; then
+        {
+            echo ""
+            echo "${GATEWAY_MARKER}"
+            echo "export COPILOT_PROVIDER_BASE_URL=\"${LITELLM_BASE_URL}/v1\""
+            echo "export COPILOT_PROVIDER_API_KEY=\"${LITELLM_API_KEY}\""
+            echo "export COPILOT_MODEL=\"gpt-5.4-mini\""
+            echo "export COPILOT_PROVIDER_WIRE_API=\"responses\""
+            echo "# <<< litellm-gateway-env (rse-plugins) <<<"
+        } >> "${BASHRC}"
+    fi
+
+    echo "[post-start] Mode: LiteLLM gateway (${LITELLM_BASE_URL})"
+    echo "[post-start] Copilot CLI will route through the gateway in new terminal sessions."
+    echo "[post-start] Copilot Chat will use the OAI-compatible extension (configured on attach)."
+else
+    echo "[post-start] Mode: Default GitHub Copilot"
+    echo "[post-start] Using your GitHub Copilot subscription models."
+    echo "[post-start] To use a LiteLLM gateway instead, set LITELLM_BASE_URL and"
+    echo "[post-start] LITELLM_API_KEY as Codespace secrets and rebuild the container."
+fi
+
+echo ""
+echo "[post-start] Ready. Run 'copilot' in the terminal to get started."


### PR DESCRIPTION
## Summary

Upgrades the devcontainer so that GitHub Copilot CLI is ready to use immediately on Codespace spin-up, with all RSE plugins pre-registered. Optionally routes Copilot CLI and Copilot Chat through a LiteLLM-compatible gateway when credentials are provided.

## Changes

**`.devcontainer/devcontainer.json`**
- Added `secrets` block declaring `LITELLM_BASE_URL` and `LITELLM_API_KEY` as optional Codespace secrets
- Added `remoteEnv` to expose `OAI_API_KEY` from `LITELLM_API_KEY`
- Added `postStartCommand` (`post-start.sh`) and `postAttachCommand` (`install-vsix.sh`) lifecycle hooks
- Added `ms-python.python` extension
- Renamed to "RSE Plugins Demo"

**`.devcontainer/post-create.sh`** (rewritten)
- Installs GitHub Copilot CLI via `https://gh.io/copilot-install`
- Registers `uw-ssec/rse-plugins` marketplace via `copilot plugin marketplace add`
- Pre-installs all 9 RSE plugins via `copilot plugin install`
- Keeps Claude Code CLI installation and `.github/agents` + `.github/skills` copy logic
- Conditionally downloads and SHA256-verifies the OAI-compatible Copilot VSIX if `LITELLM_BASE_URL` is set

**`.devcontainer/post-start.sh`** (new)
- Runs on every container start
- If `LITELLM_BASE_URL` + `LITELLM_API_KEY` are present, injects `COPILOT_PROVIDER_*` env vars into `~/.bashrc` (idempotent, marker-guarded)
- Prints mode status (LiteLLM gateway vs default GitHub Copilot)

**`.devcontainer/install-vsix.sh`** (new)
- Runs on every attach
- If `LITELLM_BASE_URL` is set, installs the cached OAI-compatible Copilot VSIX and writes VS Code machine-level settings to route Copilot Chat through the gateway
- Non-fatal: failures fall back to default GitHub Copilot

**`.devcontainer/oai-compatible-copilot-vsix.env`** (new)
- Pinned VSIX release tag, filename, and SHA256 from `uw-ssec/oai-compatible-copilot`
- Acts as a reviewed trust anchor — update only via reviewed PRs

## Testing

Validated in a GitHub Codespace spun up from this branch:
- `copilot --version` confirms CLI is installed
- `copilot plugin list` shows all 9 plugins loaded
- `.github/agents/` (30 agents) and `.github/skills/` (67 skills) correctly populated
- `post-start.sh` default mode prints correct status
- `install-vsix.sh` exits cleanly when no gateway secrets are set

## Known limitation: Codespaces secrets scoping

GitHub Codespaces user secrets can only be scoped to repositories the user owns or is a collaborator on. A user opening a Codespace directly from `uw-ssec/rse-plugins` without owning it cannot scope `LITELLM_BASE_URL` / `LITELLM_API_KEY` to that repo. Three options for users in this situation:

**Option A — Fork the repo (recommended for contributors)**
Fork `uw-ssec/rse-plugins`, create the Codespace from the fork, and scope secrets to the fork. Standard open source workflow; secrets persist across rebuilds.

**Option B — Per-codespace secrets via `gh` CLI**
After creating the Codespace, from a local terminal:
```bash
gh cs secrets set LITELLM_BASE_URL --codespace <name>
gh cs secrets set LITELLM_API_KEY --codespace <name>
```
Then restart the Codespace. No repo ownership required, but secrets are tied to one specific Codespace instance.

**Option C — Interactive setup script (future work)**
A `setup-gateway.sh` script that users run once inside the Codespace terminal — prompts for credentials and writes them to `~/.bashrc` directly. Lowest friction for users who just want to try it. Not yet implemented.

## Related

- Reference implementation: [RSE-SANDBOX devcontainer](https://github.com/Vraj1234/RSE-SANDBOX/blob/main/.devcontainer/)