### PR TITLE
fix(scientific-documentation): replace unclaimed pip placeholder with angle-bracket syntax

### DIFF
--- a/plugins/scientific-python-development/skills/scientific-documentation/references/common-issues.md
+++ b/plugins/scientific-python-development/skills/scientific-documentation/references/common-issues.md
@@ -71,12 +71,12 @@ suppress_warnings = ["toc.not_readable"]
 
 **Solution**:
 ```bash
-pip install sphinx-extension-name
+pip install <extension-name>  # e.g. sphinx-rtd-theme, myst-parser, nbsphinx
 ```
 
 Check installed extensions:
 ```bash
-python -c "import sphinx_extension_name; print(sphinx_extension_name.__version__)"
+python -c "import <extension_name>; print(<extension_name>.__version__)"
 ```
 
 ## Autodoc Issues
@@ -456,7 +456,7 @@ except ImportError:
 **Solution**: Check compatibility
 ```bash
 pip install "sphinx>=7.0"
-pip install --upgrade sphinx-extension-name
+pip install --upgrade <extension-name>  # e.g. sphinx-rtd-theme, myst-parser
 ```
 
 ## Debugging Tips


### PR DESCRIPTION
## Summary

- Replaces `sphinx-extension-name` placeholder in `common-issues.md` with `<extension-name>` (angle-bracket syntax) at all 3 occurrences
- Angle-bracket syntax is rejected by pip as invalid, making it unambiguous this is a template placeholder — not a real installable package
- Adds concrete examples (e.g. `sphinx-rtd-theme`, `myst-parser`, `nbsphinx`) to help users understand what to substitute

Closes #114

## Test plan

- [ ] Verify no remaining occurrences of `sphinx-extension-name` in the repo
- [ ] Confirm the updated examples are clear and instructive

🤖 Generated with [Claude Code](https://claude.com/claude-code)