### PR TITLE
docs(pixi-skill): refresh pixi-package-manager skill to pixi 0.72.1

### DIFF
--- a/plugins/scientific-python-development/skills/pixi-package-manager/SKILL.md
+++ b/plugins/scientific-python-development/skills/pixi-package-manager/SKILL.md
@@ -2,8 +2,8 @@
 name: pixi-package-manager
 description: "Manage scientific Python dependencies and environments with the pixi package manager: create environments, add conda-forge and PyPI packages, define and run tasks, and generate reproducible multi-platform lockfiles. Use when the user mentions pixi, pixi.toml, pixi.lock, pixi init/add/run, conda-forge, or needs reproducible scientific Python environments combining conda and PyPI packages."
 metadata:
-  pixi-version: "0.69.0"
-  last-verified: "2026-05-29"
+  pixi-version: "0.72.1"
+  last-verified: "2026-07-08"
   assets:
     - assets/github-actions-pixi.yml
     - assets/pyproject-multi-env.toml
@@ -30,7 +30,7 @@ metadata:
 curl -fsSL https://pixi.sh/install.sh | bash
 
 # Install pixi (Windows)
-iwr -useb https://pixi.sh/install.ps1 | iex
+irm -useb https://pixi.sh/install.ps1 | iex
 
 # Initialize new project with pyproject.toml
 pixi init --format pyproject
@@ -144,16 +144,9 @@ analyse = { cmd = "python scripts/analyze.py", depends-on = ["test"] }
 
 ### 5. Global Tools and One-Off Execution
 
-Not every tool belongs in a project environment:
-
-- **`pixi global install <tool>`** installs a CLI tool into an isolated global
-  environment on your `PATH` — the pixi-native replacement for `pipx`/`condax`
-  (e.g. `ruff`, `pre-commit`, `jupyterlab`).
-- **`pixi exec <cmd>`** runs a command in a temporary environment that is
-  discarded afterward — ideal for trying a tool without adding a dependency, or
-  for CI one-offs (`pixi exec --spec python=3.12 python -V`).
-- **`pixi shell-hook`** prints the activation script for an environment without
-  spawning a subshell, which is what you want in CI steps and wrapper scripts.
+Not every tool belongs in a project environment — install persistent CLI tools,
+run throwaway one-offs, or emit a subshell-free activation script for CI using
+the `global` / `exec` / `shell-hook` commands in the Quick Reference Card above.
 
 ## Quick Start
 
@@ -224,9 +217,8 @@ PyPI build failures.
 
 See [references/best-practices.md](references/best-practices.md) for checklists
 covering project setup, dependency management, reproducibility, performance, and
-development workflow — including pinning GitHub Actions to commit SHAs (not
-mutable tags) in CI; a tag like `@v5` can be repointed to malicious code, a SHA
-cannot (see [assets/github-actions-pixi.yml](assets/github-actions-pixi.yml)).
+development workflow — including SHA-pinning GitHub Actions in CI (see
+[assets/github-actions-pixi.yml](assets/github-actions-pixi.yml)).
 
 ## Resources
 

--- a/plugins/scientific-python-development/skills/pixi-package-manager/references/best-practices.md
+++ b/plugins/scientific-python-development/skills/pixi-package-manager/references/best-practices.md
@@ -19,6 +19,7 @@
 ## Reproducibility
 - [ ] Commit `pixi.lock` to version control
 - [ ] Include all platforms in lockfile for cross-platform teams
+- [ ] Pin a minimum pixi version (`pixi workspace requires-pixi set ">=0.72"`) so collaborators and CI use a compatible pixi
 - [ ] Document environment recreation steps in README
 - [ ] Use exact version pins for published research
 - [ ] Test environment from scratch periodically

--- a/plugins/scientific-python-development/skills/pixi-package-manager/references/common-issues.md
+++ b/plugins/scientific-python-development/skills/pixi-package-manager/references/common-issues.md
@@ -49,8 +49,8 @@ env2 = { features = ["feat2"], solve-group = "group2" }  # separate solver
 # Instead of: numpy==1.26.0
 # Use: numpy>=1.24,<2.0
 
-# Force specific channel priority
-pixi add numpy -c conda-forge --force-reinstall
+# Pin a package to a specific channel with MatchSpec syntax
+pixi add "conda-forge::numpy"
 ```
 
 ## Issue: Slow Environment Creation
@@ -67,8 +67,9 @@ test = { features = ["test"], solve-group = "default" }  # reuses default solve
 # Clean cache if corrupted
 pixi clean cache
 
-# Check for large dependency trees
-pixi tree --depth 2
+# Inspect the dependency tree (add -i/--invert to trace why a package is pulled in)
+pixi tree
+pixi tree -i numpy
 
 # Update pixi to latest version
 pixi self-update

--- a/plugins/scientific-python-development/skills/pixi-package-manager/references/patterns.md
+++ b/plugins/scientific-python-development/skills/pixi-package-manager/references/patterns.md
@@ -206,6 +206,9 @@ dependencies = [
     "scikit-learn=1.3.2",
 ]
 
+[tool.pixi.workspace]
+requires-pixi = ">=0.72"  # pin minimum pixi version (pixi workspace requires-pixi set)
+
 [tool.pixi.pypi-dependencies]
 # Pin with exact hashes for ultimate reproducibility
 seaborn = "==0.13.0"
@@ -254,8 +257,9 @@ pixi install  # installs exact versions from pixi.lock
 # Run complete pipeline
 pixi run full-pipeline
 
-# Archive for long-term preservation
-pixi list --json > environment-snapshot.json  # backup package list (--export removed in 0.40+)
+# Archive for long-term preservation: export the exact locked environment
+pixi workspace export conda-environment environment-snapshot.yml  # portable environment.yaml
+pixi workspace export conda-explicit-spec ./locked-specs          # fully pinned URLs per platform
 ```
 
 ## Pattern 6: Task Dependencies and Workflows


### PR DESCRIPTION
## Summary
- Refresh the `pixi-package-manager` skill from pixi **0.69.0 → 0.72.1**.
- Every documented command was verified against the installed 0.72.1 binary and cross-checked against the official docs (`llms-full.txt`).
- Fixes two commands that no longer exist in 0.72.1, adds newly-available features, and removes duplication per a skill-authoring review.

## Changes
**Correctness (commands that fail in 0.72.1):**
- `pixi add numpy -c conda-forge --force-reinstall` → `pixi add "conda-forge::numpy"` (both `-c` and `--force-reinstall` error in 0.72.1)
- `pixi tree --depth 2` → `pixi tree` / `pixi tree -i numpy` (`--depth` removed; `-i/--invert` is current)
- Windows install `iwr -useb … | iex` → `irm -useb … | iex` to match the official docs

**New capabilities (since 0.69.0):**
- `requires-pixi` minimum-version pin added to the reproducibility checklist and the reproducible-research pattern
- Lockfile archival modernized to the first-class `pixi workspace export conda-environment` / `conda-explicit-spec` commands

**Metadata & authoring cleanup:**
- Frontmatter: `pixi-version: 0.72.1`, `last-verified: 2026-07-08`
- Collapsed the duplicated `global`/`exec`/`shell-hook` concept into a pointer to the Quick Reference Card
- Kept the SHA-pinning rationale in a single source (best-practices reference + asset header); `SKILL.md` now points instead of restating
- Removed the empty `scripts/` directory

## Test plan
- [ ] `pixi --version` reports 0.72.1 (baseline for verification)
- [ ] Every command in `SKILL.md` and `references/` parses/runs on pixi 0.72.1
- [ ] `pixi add "conda-forge::numpy"`, `pixi tree -i <pkg>`, `pixi workspace requires-pixi set`, and `pixi workspace export conda-environment` all succeed
- [ ] All TOML snippets parse (Pattern 5 `requires-pixi` under `[tool.pixi.workspace]`)