### PR TITLE
fix(skills): use non-resolvable placeholders for example package names (#114)

### DIFF
--- a/community-plugins/holoviz-visualization/references/troubleshooting/README.md
+++ b/community-plugins/holoviz-visualization/references/troubleshooting/README.md
@@ -68,8 +68,8 @@ Solutions for common issues across the HoloViz ecosystem. Organized by library f
 
 **Solution**:
 ```bash
-# Install missing library
-pip install X
+# Install the missing library named in the error (replace the placeholder)
+pip install <missing-library>
 
 # Or install with specific extra
 pip install panel[recommended]
@@ -379,8 +379,8 @@ pip install panel holoviews datashader
 # Reinstall Jupyter extensions
 jupyter labextension install @pyviz/jupyterlab_pyviz
 
-# Or for JupyterLab 3+
-pip install jupyterlab_pyviz
+# Or for JupyterLab 3+ (the extension ships with pyviz_comms)
+pip install pyviz_comms
 ```
 
 ## Quick Reference: Error → Solution

--- a/plugins/containerization/skills/singularity-apptainer/SKILL.md
+++ b/plugins/containerization/skills/singularity-apptainer/SKILL.md
@@ -469,7 +469,7 @@ SIF images are read-only by default. Use overlays to add a writable layer.
 apptainer overlay create --size 500 my_overlay.img
 
 # Run with the overlay -- writes persist in my_overlay.img
-apptainer exec --overlay my_overlay.img image.sif pip install new_package
+apptainer exec --overlay my_overlay.img image.sif pip install <package-name>
 
 # Shell with overlay for interactive modification
 apptainer shell --overlay my_overlay.img image.sif
@@ -495,7 +495,7 @@ apptainer build final_image.sif my_sandbox/
 apptainer overlay create --size 200 image.sif
 
 # Now writes go into the embedded overlay
-apptainer exec --writable image.sif pip install new_package
+apptainer exec --writable image.sif pip install <package-name>
 ```
 
 ## Common Mistakes

--- a/plugins/project-management/skills/community-health-files/assets/readme-template.md
+++ b/plugins/project-management/skills/community-health-files/assets/readme-template.md
@@ -40,13 +40,13 @@
 
 ```bash
 # Example for Python (PyPI):
-pip install package-name
+pip install <package-name>
 
 # Example for Rust (crates.io):
-# cargo add package-name
+# cargo add <package-name>
 
 # Example for Node.js (npm):
-# npm install package-name
+# npm install <package-name>
 ```
 
 ### From source (for development)

--- a/plugins/scientific-python-development/skills/pixi-package-manager/references/common-issues.md
+++ b/plugins/scientific-python-development/skills/pixi-package-manager/references/common-issues.md
@@ -16,15 +16,15 @@
 
 ## Issue: Package Not Found in Conda-forge
 
-**Problem**: Running `pixi add my-package` fails with "package not found"
+**Problem**: Running `pixi add <my-package>` fails with "package not found"
 
 **Solution**:
 ```bash
-# Search conda-forge
-pixi search my-package
+# Search conda-forge (replace the placeholder with the real package name)
+pixi search <my-package>
 
 # If not in conda-forge, use PyPI
-pixi add --pypi my-package
+pixi add --pypi <my-package>
 
 # Check if package has different name in conda
 # Example: scikit-learn (PyPI) vs sklearn (conda)

--- a/plugins/scientific-python-development/skills/python-packaging/assets/readme-template.md
+++ b/plugins/scientific-python-development/skills/python-packaging/assets/readme-template.md
@@ -15,13 +15,15 @@ A Python package for [brief description of scientific purpose].
 
 ## Installation
 
+<!-- Replace <my-sci-package> with your published package name -->
+
 ```bash
-pip install my-sci-package
+pip install <my-sci-package>
 ```
 
 For plotting capabilities:
 ```bash
-pip install my-sci-package[plotting]
+pip install <my-sci-package>[plotting]
 ```
 
 ## Quick Start

--- a/plugins/scientific-python-development/skills/python-packaging/references/metadata.md
+++ b/plugins/scientific-python-development/skills/python-packaging/references/metadata.md
@@ -102,11 +102,11 @@ all = [
 ]
 ```
 
-**Install with extras:**
+**Install with extras** (replace the placeholder with your package name):
 ```bash
-pip install my-sci-package[plotting]
-pip install my-sci-package[plotting,ml]
-pip install my-sci-package[all]
+pip install <my-sci-package>[plotting]
+pip install <my-sci-package>[plotting,ml]
+pip install <my-sci-package>[all]
 ```
 
 ## Development Dependencies (Dependency Groups)

--- a/plugins/scientific-python-development/skills/scientific-documentation/SKILL.md
+++ b/plugins/scientific-python-development/skills/scientific-documentation/SKILL.md
@@ -747,7 +747,7 @@ Doe, J. (2024). My Scientific Package (Version 0.1.0) [Computer software]. https
 
 Install exact versions:
 \`\`\`bash
-pip install package==0.1.0
+pip install <package-name>==0.1.0
 \`\`\`
 
 Or from `requirements.txt`:

--- a/plugins/scientific-python-development/skills/scientific-documentation/assets/index-template.md
+++ b/plugins/scientific-python-development/skills/scientific-documentation/assets/index-template.md
@@ -10,10 +10,10 @@ A powerful scientific Python package for [describe main purpose].
 
 ## Quick Start
 
-Install the package:
+Install the package (replace the placeholder with your published package name):
 
 ```bash
-pip install mypackage
+pip install <mypackage>
 ```
 
 Basic usage:

--- a/plugins/scientific-python-development/skills/scientific-documentation/references/common-issues.md
+++ b/plugins/scientific-python-development/skills/scientific-documentation/references/common-issues.md
@@ -69,14 +69,14 @@ suppress_warnings = ["toc.not_readable"]
 
 **Problem**: Required extension not installed
 
-**Solution**:
+**Solution**: Install the extension named in the error (replace the placeholder):
 ```bash
-pip install sphinx-extension-name
+pip install <sphinx-extension-name>  # e.g. pip install sphinx-copybutton
 ```
 
-Check installed extensions:
+Verify it is importable:
 ```bash
-python -c "import sphinx_extension_name; print(sphinx_extension_name.__version__)"
+python -c "import sphinx_copybutton; print(sphinx_copybutton.__version__)"
 ```
 
 ## Autodoc Issues
@@ -456,7 +456,7 @@ except ImportError:
 **Solution**: Check compatibility
 ```bash
 pip install "sphinx>=7.0"
-pip install --upgrade sphinx-extension-name
+pip install --upgrade <sphinx-extension-name>  # replace with the failing extension
 ```
 
 ## Debugging Tips

--- a/plugins/uiux-design-team/skills/typography-systems/SKILL.md
+++ b/plugins/uiux-design-team/skills/typography-systems/SKILL.md
@@ -28,7 +28,7 @@ Pick by use case (full table in [type-scale-theory.md](references/type-scale-the
 
 ### Step 2 — Generate the scale
 
-Base 16px (or 1rem). Multiply up, divide down. Tools: `npx type-scale-generator`, or by hand. Worked example in [type-scale-theory.md](references/type-scale-theory.md).
+Base 16px (or 1rem). Multiply up, divide down — by hand, or with any browser-based type-scale calculator. Worked example in [type-scale-theory.md](references/type-scale-theory.md).
 
 ```css
 :root {


### PR DESCRIPTION
## Summary

Fixes #114. A security researcher (Blue Bear Security) reported that the `scientific-documentation` skill instructs users to run `pip install sphinx-extension-name` — a **registry-resolvable placeholder name**. Because skills in this repo are markdown that coding agents execute literally, and the name resolves on PyPI, copy-pasting the command installs a third-party package whose sdist can run arbitrary code via `setup.py` (dependency-confusion / typosquat class). `sphinx-extension-name` and `package-name` are now **live on PyPI** (the former published defensively by the reporter), so this is not hypothetical.

Rather than fix only the one cited line, this PR sweeps the whole repo for the underlying class — registry-resolvable placeholder names in **agent-executed** package commands — and wraps each in `<angle-brackets>` so the name cannot resolve on any registry and the shell errors out instead of silently installing a squatted package.

## Changes

**`48cd418` — placeholder install commands (9 files)**

| File | Fix |
|---|---|
| `scientific-documentation/references/common-issues.md` | `sphinx-extension-name` → `<sphinx-extension-name>` (+ real example `sphinx-copybutton`) |
| `community-health-files/assets/readme-template.md` | `package-name` → `<package-name>` (pip/cargo/npm) |
| `python-packaging/references/metadata.md`, `assets/readme-template.md` | `my-sci-package` → `<my-sci-package>` (was unclaimed on PyPI) |
| `scientific-documentation/SKILL.md`, `assets/index-template.md` | `package` / `mypackage` → `<package-name>` / `<mypackage>` |
| `pixi-package-manager/references/common-issues.md` | `pixi add my-package` → `<my-package>` |
| `singularity-apptainer/SKILL.md` | `new_package` → `<package-name>` |
| `holoviz-visualization/.../troubleshooting/README.md` | `pip install X` → `<missing-library>`; `jupyterlab_pyviz` → `pyviz_comms` (the real package shipping that extension) |

**`43ae887` — `npx type-scale-generator` in `typography-systems/SKILL.md`**

A whole-repo scan caught one the install-command grep missed because it's an `npx` invocation: the name is **unclaimed on npm (HTTP 404)** — identical RCE-via-typosquat risk. Replaced with the by-hand method already documented in that step.

## Notes

- `validate-project-handoff.md:133` keeps `pip install my-package` intentionally — it's inside illustrative *report output* (a validator's finding), not an install instruction.
- All other `pip`/`npx`/`uvx`/`conda`/`gem` names across tracked skills were verified as claimed on their registries.
- The broader scan surfaced three unrelated findings (a `marketplace.json` duplicate-key CI scan-bypass, a broken secret-scan regex in `validate-plugins.yml`, and an unpinned `:latest` MCP image); these are out of scope for this branch and are being tracked separately.

## Test plan

- [x] Every changed placeholder verified to no longer resolve on its registry (angle-bracketed names are non-resolvable; `type-scale-generator` removed).
- [x] Real substitutions verified to exist on their registry (`sphinx-copybutton`, `pyviz_comms`).
- [x] `grep` confirms no remaining bare registry-resolvable placeholder in an agent-executed install/run command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)