### PR TITLE
fix(marketplace): restore gaia entry lost to duplicate JSON keys

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -114,9 +114,6 @@
             "name": "gaia-data-downloader",
             "source": "./community-plugins/gaia-data-downloader",
             "description": "Generate and develop hydroclimatological data download scripts for GAIA geoscience research",
-            "name": "zarr-chunk-optimization",
-            "source": "./plugins/zarr-chunk-optimization",
-            "description": "Benchmark and optimize Zarr chunking strategies for multi-dimensional scientific datasets on cloud object stores (S3, GCS)",
             "homepage": "https://github.com/uw-ssec/rse-plugins",
             "repository": "https://github.com/uw-ssec/rse-plugins",
             "license": "BSD-3-Clause",
@@ -131,7 +128,26 @@
                 "environmental-data"
             ],
             "category": "data-science",
-            "strict": false,
+            "strict": false
+        },
+        {
+            "name": "zarr-chunk-optimization",
+            "source": "./plugins/zarr-chunk-optimization",
+            "description": "Benchmark and optimize Zarr chunking strategies for multi-dimensional scientific datasets on cloud object stores (S3, GCS)",
+            "homepage": "https://github.com/uw-ssec/rse-plugins",
+            "repository": "https://github.com/uw-ssec/rse-plugins",
+            "license": "BSD-3-Clause",
+            "keywords": [
+                "zarr",
+                "chunking",
+                "benchmarking",
+                "cloud-storage",
+                "performance-optimization",
+                "rechunking",
+                "access-patterns",
+                "scientific-data",
+                "research-software"
+            ],
             "category": "data-science",
             "strict": false
         },

--- a/.github/scripts/check_duplicate_json_keys.py
+++ b/.github/scripts/check_duplicate_json_keys.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Fail CI if any JSON file contains duplicate keys within an object.
+
+The sibling ``jq empty`` validation step accepts duplicate keys: JSON parsers
+keep the *last* value for a repeated key, so a duplicated key is silently
+collapsed rather than reported as invalid. In ``.claude-plugin/marketplace.json``
+that last-wins behavior can drop an entire plugin entry from the catalog — and
+because the security scans build their target list from that catalog, the
+dropped plugin's files stop being scanned. This check walks every JSON file and
+rejects duplicate keys so that class of defect fails loudly.
+
+Usage:
+    check_duplicate_json_keys.py [ROOT ...]
+
+Each ROOT may be a directory (scanned recursively for ``*.json``) or a single
+JSON file. Defaults to the current directory.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+# Directories that never contain first-party JSON worth validating.
+SKIP_DIR_PARTS = {".git", "node_modules"}
+
+
+def reject_duplicates(pairs):
+    """object_pairs_hook that raises on the first duplicate key it sees."""
+    seen = set()
+    for key, _value in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate key: {key!r}")
+        seen.add(key)
+    return dict(pairs)
+
+
+def iter_json_files(roots):
+    for root in roots:
+        path = pathlib.Path(root)
+        candidates = [path] if path.is_file() else sorted(path.rglob("*.json"))
+        for candidate in candidates:
+            # tsconfig*.json is JSONC (allows comments); the jq step skips it too.
+            if candidate.name.startswith("tsconfig"):
+                continue
+            if SKIP_DIR_PARTS.intersection(candidate.parts):
+                continue
+            yield candidate
+
+
+def main(argv):
+    roots = argv[1:] or ["."]
+    failed = False
+    for path in iter_json_files(roots):
+        try:
+            json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicates)
+        except ValueError as exc:
+            print(f"::error file={path}::{exc}")
+            print(f"❌ {path}: {exc}")
+            failed = True
+
+    if failed:
+        print("Duplicate JSON keys detected — each JSON object must have unique keys.")
+        return 1
+    print("✅ No duplicate JSON keys detected")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     paths:
       - 'plugins/**'
+      - 'community-plugins/**'
       - '.claude-plugin/**'
       - 'marketplace/**'
       - '.github/workflows/validate-plugins.yml'
+      - '.github/scripts/**'
   push:
     branches: [ main ]
 
@@ -29,6 +31,15 @@ jobs:
               fi
             done
           ' sh {} +
+
+      - name: Check for duplicate JSON keys
+        run: |
+          echo "Checking for duplicate JSON keys..."
+          # `jq empty` above accepts duplicate keys (JSON parsers keep the last
+          # value), so a duplicated key silently collapses two objects into one.
+          # In marketplace.json that can drop a plugin from the catalog — and thus
+          # from the catalog-driven scans below — with no validation error.
+          python3 .github/scripts/check_duplicate_json_keys.py .
 
       - name: Check plugin structure
         run: |
@@ -83,8 +94,10 @@ jobs:
           echo "Scanning for hardcoded secrets..."
           FOUND_SECRETS=0
 
-          # Get all local plugin directories from marketplace
-          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json | tr '\n' ' ')
+          # Enumerate plugin directories from the filesystem (not just the catalog)
+          # so unlisted or mis-cataloged plugins are still scanned. A duplicate-key
+          # defect or a missing catalog entry must not silently skip a plugin here.
+          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null | tr '\n' ' ')
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0
@@ -151,8 +164,10 @@ jobs:
           echo "Scanning for dangerous command patterns..."
           FOUND_ISSUES=0
 
-          # Get all local plugin directories from marketplace
-          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json | tr '\n' ' ')
+          # Enumerate plugin directories from the filesystem (not just the catalog)
+          # so unlisted or mis-cataloged plugins are still scanned. A duplicate-key
+          # defect or a missing catalog entry must not silently skip a plugin here.
+          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null | tr '\n' ' ')
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0
@@ -196,8 +211,10 @@ jobs:
         run: |
           echo "Scanning for suspicious URLs..."
 
-          # Get all local plugin directories from marketplace
-          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json | tr '\n' ' ')
+          # Enumerate plugin directories from the filesystem (not just the catalog)
+          # so unlisted or mis-cataloged plugins are still scanned. A duplicate-key
+          # defect or a missing catalog entry must not silently skip a plugin here.
+          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null | tr '\n' ' ')
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0
@@ -219,8 +236,9 @@ jobs:
         run: |
           echo "Scanning MCP plugin dependencies..."
 
-          # Get all local plugin directories from marketplace
-          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json)
+          # Enumerate plugin directories from the filesystem (not just the catalog)
+          # so unlisted or mis-cataloged plugins are still scanned.
+          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -94,10 +94,8 @@ jobs:
           echo "Scanning for hardcoded secrets..."
           FOUND_SECRETS=0
 
-          # Enumerate plugin directories from the filesystem (not just the catalog)
-          # so unlisted or mis-cataloged plugins are still scanned. A duplicate-key
-          # defect or a missing catalog entry must not silently skip a plugin here.
-          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null | tr '\n' ' ')
+          # Get all local plugin directories from marketplace
+          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json | tr '\n' ' ')
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0
@@ -164,10 +162,8 @@ jobs:
           echo "Scanning for dangerous command patterns..."
           FOUND_ISSUES=0
 
-          # Enumerate plugin directories from the filesystem (not just the catalog)
-          # so unlisted or mis-cataloged plugins are still scanned. A duplicate-key
-          # defect or a missing catalog entry must not silently skip a plugin here.
-          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null | tr '\n' ' ')
+          # Get all local plugin directories from marketplace
+          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json | tr '\n' ' ')
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0
@@ -211,10 +207,8 @@ jobs:
         run: |
           echo "Scanning for suspicious URLs..."
 
-          # Enumerate plugin directories from the filesystem (not just the catalog)
-          # so unlisted or mis-cataloged plugins are still scanned. A duplicate-key
-          # defect or a missing catalog entry must not silently skip a plugin here.
-          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null | tr '\n' ' ')
+          # Get all local plugin directories from marketplace
+          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json | tr '\n' ' ')
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0
@@ -236,9 +230,8 @@ jobs:
         run: |
           echo "Scanning MCP plugin dependencies..."
 
-          # Enumerate plugin directories from the filesystem (not just the catalog)
-          # so unlisted or mis-cataloged plugins are still scanned.
-          PLUGIN_DIRS=$(find plugins community-plugins -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+          # Get all local plugin directories from marketplace
+          PLUGIN_DIRS=$(jq -r '.plugins[].source | select(startswith("./"))' .claude-plugin/marketplace.json)
           if [ -z "$PLUGIN_DIRS" ]; then
             echo "No local plugins to scan"
             exit 0


### PR DESCRIPTION
## Summary
- `.claude-plugin/marketplace.json` had a single object with **duplicate keys**: `gaia-data-downloader`'s `name`/`source`/`description` were merged into the `zarr-chunk-optimization` object. JSON last-wins parsing collapsed the two into one entry, so `gaia-data-downloader` silently vanished from the catalog and zarr's keywords were overwritten with gaia's.
- This broke `copilot plugin install gaia-data-downloader@rse-plugins` (used in `.devcontainer/post-create.sh`) — see #105 — and, because every CI security scan builds its target list from `jq -r '.plugins[].source'`, it also dropped gaia's files out of scan scope while it was missing from the catalog.
- Fix restores the catalog and adds a **duplicate-key CI guard** (`jq empty` accepts duplicate keys, so this defect class passed validation). With the entry restored and the guard in place, gaia stays in the catalog and therefore in scan scope.

## Changes
**Catalog (`.claude-plugin/marketplace.json`)**
- Split the merged object into two well-formed entries; `jq -r '.plugins[].name'` now lists **9** plugins including both `gaia-data-downloader` and `zarr-chunk-optimization`.
- Restored each plugin's own keywords (zarr had been carrying gaia's keywords after the merge). Values recovered from git history (#77) and the plugins' `plugin.json` manifests.

**CI (`.github/workflows/validate-plugins.yml`)**
- New **"Check for duplicate JSON keys"** step running `.github/scripts/check_duplicate_json_keys.py`, which uses Python's `object_pairs_hook` to reject duplicate keys (`jq empty` cannot detect them).
- Added `community-plugins/**` and `.github/scripts/**` to the `pull_request` `paths:` filter so community-plugin and CI-script changes trigger the workflow (previously community-only PRs skipped it entirely).

**New file**
- `.github/scripts/check_duplicate_json_keys.py` — walks all `*.json` (skipping `tsconfig*`, `.git`, `node_modules`) and fails on any duplicate key, emitting a GitHub Actions error annotation.

## Test plan
- [x] `jq -r '.plugins[].name'` lists 9 plugins incl. `gaia-data-downloader` **and** `zarr-chunk-optimization`
- [x] `jq -r '.plugins[].source'` includes `./community-plugins/gaia-data-downloader`; zarr keywords restored to its own (not gaia's)
- [x] Duplicate-key guard **fails** on the pre-fix file and **passes** across the whole repo (23 JSON files)
- [x] Catalog-based security scans verified clean over all 9 cataloged sources (regex checked with GNU `\s` semantics)
- [x] Structure/catalog validation passes for all 9 sources (each has `plugin.json` + `README.md`)
- [ ] CI `Validate Plugins` workflow green on this PR

## Notes / follow-up
- The security scans remain **catalog-based** by design. I explored switching them to enumerate `plugins/*` + `community-plugins/*` from the filesystem (so unlisted plugins are scanned too), but that pulls the unlisted `supply-chain-security` plugin into scope, whose incident-response runbooks legitimately *document* attack patterns (`base64 -d`, `eval(...)`) and trip the dangerous-pattern heuristics. Since this repo's plugins are largely Markdown, cleanly separating security *documentation* from dangerous *code* is a separate design change and is left as a follow-up. The duplicate-key guard already closes the reported gap (a plugin can no longer silently drop out of the catalog).

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)