### PR TITLE
fix(gaia-skill): drop nonstandard version frontmatter key

### DIFF
--- a/community-plugins/gaia-data-downloader/skills/download-script-dev/SKILL.md
+++ b/community-plugins/gaia-data-downloader/skills/download-script-dev/SKILL.md
@@ -9,7 +9,6 @@ description: >
   context of downloading or processing data. Provides templates, configuration
   validation, and debugging guidance for hydroclimatological data download scripts
   used in the GAIA project.
-version: 2026-03-20
 ---
 
 # Download Script Development Skill


### PR DESCRIPTION
## Summary
- The agentskills.io skill schema allows only specific frontmatter keys; consumers that enforce it — including `inspect_ai.tool.read_skills`, which the upcoming eval harness uses — reject `download-script-dev/SKILL.md` with `Additional properties are not allowed ('version' was unexpected)`.
- Removes the `version: 2026-03-20` key from that skill's frontmatter. The value was a redundant date stamp: the plugin's canonical version lives in `plugin.json` (`0.1.0`), and edit history lives in git, so nothing is relocated.
- Audited all 76 `SKILL.md` files under `plugins/` and `community-plugins/`: this was the only file with a nonstandard key (every other file uses only `name`, `description`, and `metadata`). After the fix, all 76 validate cleanly.

## Changes
- `community-plugins/gaia-data-downloader/skills/download-script-dev/SKILL.md`: delete the `version:` frontmatter key (1 line).

## Test plan
- [x] `read_skills` on every skill directory under `plugins/` and `community-plugins/` reports 76/76 valid (was 75/76, with this file the sole failure). Reproduce with:
  ```bash
  uv run --with inspect-ai python -c "
  from pathlib import Path
  from inspect_ai.tool import read_skills
  dirs = [p.parent for b in ('plugins','community-plugins') for p in Path(b).rglob('SKILL.md')]
  print(len(read_skills(dirs)), 'valid of', len(dirs))"
  ```
- [ ] CI validate-plugins workflow passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)