### PR TITLE
feat(marketplace): add uiux-design-team to marketplace listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -190,6 +190,28 @@
             ],
             "category": "research",
             "strict": false
+        },
+        {
+            "name": "uiux-design-team",
+            "source": "./plugins/uiux-design-team",
+            "description": "Comprehensive UI/UX design team simulation with 10 specialized agents covering user research, information architecture, interaction and visual design, accessibility auditing, design systems, and design review orchestration",
+            "homepage": "https://github.com/uw-ssec/rse-plugins",
+            "repository": "https://github.com/uw-ssec/rse-plugins",
+            "license": "BSD-3-Clause",
+            "keywords": [
+                "ui",
+                "ux",
+                "design-systems",
+                "accessibility",
+                "wcag",
+                "user-research",
+                "interaction-design",
+                "visual-design",
+                "responsive-design",
+                "design-review"
+            ],
+            "category": "design",
+            "strict": false
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ Generate and develop hydroclimatological data download scripts for the GAIA proj
 
 **When to use:** Downloading hydroclimatological data for GAIA geoscience research, creating reproducible data pipelines, setting up new data download workflows
 
+### UI/UX Design Team Plugin
+
+Comprehensive UI/UX design team simulation with 10 specialized agents covering the full design lifecycle — user research, information architecture, interaction design, visual design, motion design, design systems engineering, accessibility auditing, UX writing, and design operations.
+
+**Agent:**
+- **UX Design Lead** - Coordinator agent that facilitates design thinking, conducts design critiques, and orchestrates 9 specialist agents (research, information architecture, interaction, visual, motion, design systems, accessibility, writing, ops) across the full design lifecycle
+
+**Commands (10):**
+- `/design-review`, `/audit-accessibility`, `/create-design-system`, `/create-persona`, `/create-type-scale`, `/design-handoff`, `/evaluate-usability`, `/frontend-design`, `/generate-palette`, `/map-journey`
+
+**Skills (22):**
+- **user-research**, **information-architecture**, **wireframing**, **visual-design**, **motion-design**, **design-tokens**, **design-system-creation**, **component-library**, **accessibility-audit**, **ux-writing**, **responsive-design**, **css-architecture**, **frontend-components**, **usability-evaluation**, **design-philosophies**, **design-case-studies**, **user-journey-mapping**, **ab-testing-strategy**, **design-handoff**, **color-systems**, **typography-systems**, **grid-layout-systems**
+
+**When to use:** UI/UX design work, design system creation, accessibility audits, usability evaluation, user research and persona creation, design reviews, frontend component design, design-to-development handoff
+
 Browse the [plugins directory](plugins/) and [community-plugins directory](community-plugins/) to explore all available plugins.
 
 ## Repository Structure


### PR DESCRIPTION
## Summary
- The `uiux-design-team` plugin already existed under `plugins/uiux-design-team` but was never registered in `.claude-plugin/marketplace.json`, so `/plugin install uiux-design-team@rse-plugins` couldn't find it.
- Adds the missing marketplace entry (license `BSD-3-Clause` to match the marketplace-wide convention; category `design`, a new category alongside the existing `data-science`/`development`/`research`).
- Documents the plugin in the README's Available Plugins section, matching the format and length of existing entries.

## Test plan
- [x] `.claude-plugin/marketplace.json` validated as well-formed JSON
- [x] `/plugin marketplace add uw-ssec/rse-plugins` (or update) then `/plugin install uiux-design-team@rse-plugins` resolves and installs successfully