### PR TITLE
docs: add VS Code installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This repository provides specialized agents and skills that understand the uniqu
 
 ## Installation
 
+### Claude Code
+
 To use these agents and skills in Claude Code, add this repository to your plugin marketplace:
 
 ```bash
@@ -44,6 +46,20 @@ To use these agents and skills in Claude Code, add this repository to your plugi
 ```
 
 Once installed, the agents and skills will be available in your Claude Code environment and can be invoked when working on scientific software projects.
+
+### VS Code
+
+To configure plugin marketplaces in VS Code, use the `chat.plugins.marketplaces` setting.
+
+Here's an example that can be added to the `settings.json` file.
+
+```json
+"chat.plugins.marketplaces": [
+    "uw-ssec/rse-plugins"
+]
+```
+
+([Documentation link](https://code.visualstudio.com/docs/agent-customization/agent-plugins#_configure-plugin-marketplaces))
 
 ## Available Plugins
 


### PR DESCRIPTION
## Motivation

Current installation instructions assume the user is either using Claude Code or otherwise has `claude` installed on their machines. The available command fails to run in VS Code on machines without `claude`,  but because VS Code can support external plugin marketplaces on its own without a `claude` dependency, it is a simple documentation change to accommodate VS Code users as well.

## Testing

On a machine that did not have `claude` installed

1. Entered the existing Claude Code `/plugin` command into Copilot chat and verified that it wanted to install `claude` in order for the installation to work (the plugin marketplace addition failed when `claude` installation permissions were denied.
2. Used the VS Code installation instructions on that same machine, and verified that the plugins were visible in the VS Code window.